### PR TITLE
Remove question - How Will the trust benefit the transferring academies? 

### DIFF
--- a/app/routes/alpha-sprint-16.js
+++ b/app/routes/alpha-sprint-16.js
@@ -1036,15 +1036,6 @@ module.exports = function (router) {
         res.redirect('reason-and-benefits-trust');
     });
 
-    // POST handler for reason and benefits trust benefit trust
-    router.post('/' + version + '/reason-and-benefits-trust-benefit-trust-handler', function (req, res) {
-        // Save the benefit trust data to session
-        req.session.data['reason-and-benefits-trust-benefit-trust'] = req.body['reason-and-benefits-trust-benefit-trust'];
-        
-        // Redirect to the reason and benefits trust summary page
-        res.redirect('reason-and-benefits-trust');
-    });
-
     // POST handler for reason and benefits trust transfer type
     router.post('/' + version + '/reason-and-benefits-trust-transfer-type-handler', function (req, res) {
         // Save the transfer type data to session

--- a/app/views/alpha-sprint-16/check-your-answers.html
+++ b/app/views/alpha-sprint-16/check-your-answers.html
@@ -302,7 +302,7 @@
         {% endif %}
       </div>
       <div class="govuk-summary-card__content">
-        {% if not data['reason-and-benefits-trust-strategic-needs'] and not data['reason-and-benefits-trust-maintain-improve'] and not data['reason-and-benefits-trust-benefit-trust'] %}
+        {% if not data['reason-and-benefits-trust-strategic-needs'] and not data['reason-and-benefits-trust-maintain-improve'] %}
           <div class="govuk-inset-text">
             No reason and benefits information has been added.
           </div>
@@ -326,17 +326,6 @@
               </dt>
               <dd class="govuk-summary-list__value">
                 {{ data['reason-and-benefits-trust-maintain-improve'] }}
-              </dd>
-            </div>
-            {% endif %}
-
-            {% if data['reason-and-benefits-trust-benefit-trust'] %}
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                How will the trust benefit the transferring academies?
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ data['reason-and-benefits-trust-benefit-trust'] }}
               </dd>
             </div>
             {% endif %}

--- a/app/views/alpha-sprint-16/reason-and-benefits-trust-benefit-trust.html
+++ b/app/views/alpha-sprint-16/reason-and-benefits-trust-benefit-trust.html
@@ -1,41 +1,9 @@
 {% extends "layouts/main.html" %}
 
-{% set pageName="How will the transferring academies benefit the trust" %}
-
-{% block beforeContent %}
-  {{ govukBackLink({
-    text: "Back",
-    href: "javascript:window.history.back()"
-  }) }}
-{% endblock %}
+{% set pageName="Redirect" %}
 
 {% block content %}
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
-
-    <form action="reason-and-benefits-trust-benefit-trust-handler" method="post">
-
-        {{ govukCharacterCount({
-          label: {
-            html: '<span class="govuk-caption-l">Reason and benefits</span>
-            How will the trust benefit the transferring academies?',
-            classes: "govuk-label--l",
-            isPageHeading: true
-          },
-          maxlength: 4000,
-          id: "reason-and-benefits-trust-benefit-trust",
-          name: "reason-and-benefits-trust-benefit-trust",
-          value: data["reason-and-benefits-trust-benefit-trust"]
-        }) }}
-
-        {{ govukButton({
-          text: "Continue"
-        }) }}
-
-      </form>
-    
-  </div>
-</div>
-
+<script>
+  window.location.href = 'reason-and-benefits-trust';
+</script>
 {% endblock %} 

--- a/app/views/alpha-sprint-16/reason-and-benefits-trust-benefit-trust.html
+++ b/app/views/alpha-sprint-16/reason-and-benefits-trust-benefit-trust.html
@@ -1,9 +1,0 @@
-{% extends "layouts/main.html" %}
-
-{% set pageName="Redirect" %}
-
-{% block content %}
-<script>
-  window.location.href = 'reason-and-benefits-trust';
-</script>
-{% endblock %} 

--- a/app/views/alpha-sprint-16/reason-and-benefits-trust.html
+++ b/app/views/alpha-sprint-16/reason-and-benefits-trust.html
@@ -50,19 +50,6 @@
           </a>
         </dd>
       </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          How will the trust benefit the transferring academies?
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{ data['reason-and-benefits-trust-benefit-trust'] }}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="reason-and-benefits-trust-benefit-trust">
-            Change<span class="govuk-visually-hidden"> how will the trust benefit the transferring academies</span>
-          </a>
-        </dd>
-      </div>
       <!-- Temporarily hidden: What type of transfer it is?
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "external-applications",
+  "name": "external-applications-prototype",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Changes in this PR:
The question "How will the trust benefit the transferring academies?" has now been removed from all relevant files, including:
All conditional logic and references to its data such as:
The form page for this question
The summary and check-your-answers pages
The backend route handler


## Screenshots of UI changes:
<img width="728" height="505" alt="Screenshot 2025-07-10 at 14 02 40" src="https://github.com/user-attachments/assets/5d848d0c-e726-47e9-8f70-50b536d089fe" />
