### PR TITLE
Added sprint 18

### DIFF
--- a/app/data/data-alpha-sprint-18.js
+++ b/app/data/data-alpha-sprint-18.js
@@ -1,0 +1,156 @@
+module.exports = {
+    'academies': [
+        {
+            name: "St George's Primary Academy",
+            urn: "123456",
+            postcode: "SW1A 1AA",
+            academyTrust: "London Education Trust"
+        },
+        {
+            name: "Hammersmith Primary Academy",
+            urn: "123457",
+            postcode: "W6 7BS",
+            academyTrust: "London Education Trust"
+        },
+        {
+            name: "Riverside Primary Academy",
+            urn: "123458",
+            postcode: "SE1 7PB",
+            academyTrust: "London Education Trust"
+        },
+        {
+            name: "Oak Tree Primary Academy",
+            urn: "123459",
+            postcode: "E1 6AN",
+            academyTrust: "London Education Trust"
+        },
+        {
+            name: "Meadowbrook Primary Academy",
+            urn: "123460",
+            postcode: "N1 9GU",
+            academyTrust: "Northern Learning Trust"
+        },
+        {
+            name: "Sunnydale Primary Academy",
+            urn: "123461",
+            postcode: "NW1 4RY",
+            academyTrust: "Northern Learning Trust"
+        },
+        {
+            name: "Greenfield Primary Academy",
+            urn: "123462",
+            postcode: "EC1A 1BB",
+            academyTrust: "Northern Learning Trust"
+        },
+        {
+            name: "Valley Primary Academy",
+            urn: "123463",
+            postcode: "SW19 5AE",
+            academyTrust: "Southern Multi-Academy Trust"
+        },
+        {
+            name: "Hillside Primary Academy",
+            urn: "123464",
+            postcode: "W1D 3AF",
+            academyTrust: "Southern Multi-Academy Trust"
+        },
+        {
+            name: "Brookside Primary Academy",
+            urn: "123465",
+            postcode: "SE10 8EW",
+            academyTrust: "Southern Multi-Academy Trust"
+        }
+    ],
+    'members': [
+        {
+            name: "John Smith",
+            role: "Chair of Trustees",
+            email: "john.smith@example.com"
+        },
+        {
+            name: "Sarah Johnson",
+            role: "Vice Chair",
+            email: "sarah.johnson@example.com"
+        },
+        {
+            name: "Michael Brown",
+            role: "Trustee",
+            email: "michael.brown@example.com"
+        },
+        {
+            name: "Emma Wilson",
+            role: "Trustee",
+            email: "emma.wilson@example.com"
+        },
+        {
+            name: "David Thompson",
+            role: "Trustee",
+            email: "david.thompson@example.com"
+        },
+        {
+            name: "Lisa Davis",
+            role: "Trustee",
+            email: "lisa.davis@example.com"
+        },
+        {
+            name: "Robert Miller",
+            role: "Trustee",
+            email: "robert.miller@example.com"
+        },
+        {
+            name: "Jennifer Garcia",
+            role: "Trustee",
+            email: "jennifer.garcia@example.com"
+        }
+    ],
+    'applications': [
+        {
+            'reference': "240315-ABC34",
+            'dateStarted': "15 March 2025",
+            'status': "Not submitted",
+            'leadApplicant': "Arden Laney",
+            'taskOwners': {
+                'academies': "",
+                'incomingTrust': "",
+                'finance': "",
+                'declaration': ""
+            },
+            'contributors': [
+                {
+                    name: "Arden Laney",
+                    email: "arden.laney@test.org"
+                }
+            ]
+        },
+        {
+            'reference': "240315-XYZ45",
+            'dateStarted': "15 March 2025",
+            'status': "Not submitted",
+            'leadApplicant': "Arden Laney",
+            'taskOwners': {
+                'academies': ["arden.laney@test.org"],
+                'incomingTrust': ["john.smith@test.org"],
+                'finance': ["sarah.johnson@test.org"],
+                'declaration': ""
+            },
+            'contributors': [
+                {
+                    name: "Arden Laney",
+                    email: "arden.laney@test.org"
+                },
+                {
+                    name: "John Smith",
+                    email: "john.smith@test.org"
+                },
+                {
+                    name: "Sarah Johnson",
+                    email: "sarah.johnson@test.org"
+                }
+            ],
+            'academies-to-transfer': ["123456", "123457"],
+            'academies-to-transfer-status': true,
+            'incoming-trust-status': false,
+            'finance-status': false
+        }
+    ]
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -19,3 +19,4 @@ require('./routes/alpha-sprint-11.js')(router);
 require('./routes/alpha-sprint-12.js')(router);
 require('./routes/alpha-sprint-14.js')(router);
 require('./routes/alpha-sprint-16.js')(router);
+require('./routes/alpha-sprint-18.js')(router);

--- a/app/routes/alpha-sprint-18.js
+++ b/app/routes/alpha-sprint-18.js
@@ -1,0 +1,1785 @@
+// Add your routes here - above the module.exports line
+var versionMiddleware = require("./versionMiddleware")
+const data = require('../data/data-alpha-sprint-18');
+
+module.exports = function (router) {
+
+    var version = "alpha-sprint-18";
+
+    versionMiddleware(router, version);
+
+    // Add file upload middleware for governance structure
+    router.use('/' + version + '/governance-structure-model-handler', (req, res, next) => {
+        // For this prototype, we'll simulate file upload handling
+        // In a real application, you would use multer or similar middleware
+        if (req.headers['content-type'] && req.headers['content-type'].includes('multipart/form-data')) {
+            // Simulate file upload processing
+            req.files = {
+                'governance-structure-file': {
+                    name: 'governance-structure-document.pdf',
+                    size: 1024000, // 1MB
+                    mimetype: 'application/pdf'
+                }
+            };
+        }
+        next();
+    });
+
+
+    // Handle academy search results page
+    router.get('/' + version + '/academies-to-transfer-search-results', function (req, res) {
+        const radioItems = data.academies.map(academy => ({
+            value: academy.name + "|||" + academy.urn + "|||" + academy.postcode + "|||" + academy.academyTrust,
+            text: academy.name,
+            hint: {
+                html: `URN: ${academy.urn} | Postcode: ${academy.postcode}<br>Trust: ${academy.academyTrust}`
+            }
+        }));
+
+        res.render(version + '/academies-to-transfer-search-results', {
+            radioItems: radioItems
+        });
+    });
+
+    // Handle academy selection
+    router.post('/' + version + '/academies-to-transfer-confirmation', function (req, res) {
+        // Store the selected academy in session
+        const selectedAcademy = req.body['selected-academy'];
+        const [name, urn, postcode, academyTrust] = selectedAcademy.split('|||');
+        
+        // Find the full academy details from the data file
+        const academy = data.academies.find(a => a.urn === urn);
+        
+        // Store the full academy details in session
+        req.session.data['selected-academy'] = selectedAcademy;
+        req.session.data['selected-academy-details'] = academy;
+        
+        res.render(version + '/academies-to-transfer-confirmation', {
+            data: req.session.data,
+            academy: academy
+        });
+    });
+
+    // Handle academy confirmation
+    router.post('/' + version + '/add-more-academies-handler', function (req, res) {
+        const confirmAcademy = req.session.data['confirm-academy'];
+        
+        if (confirmAcademy === 'yes') {
+            // Get the selected academy details
+            const selectedAcademy = req.session.data['selected-academy'];
+            const [name, urn, postcode, academyTrust] = selectedAcademy.split('|||');
+
+            // Initialize academies-to-transfer array if it doesn't exist
+            if (!req.session.data['academies-to-transfer']) {
+                req.session.data['academies-to-transfer'] = [];
+            }
+
+            // Add the new academy to the list
+            req.session.data['academies-to-transfer'].push({
+                name: name,
+                urn: urn,
+                postcode: postcode,
+                academyTrust: academyTrust
+            });
+
+            // Clear any existing errors since we now have an academy
+            delete req.session.data.errors;
+        }
+        
+        // Always go to academies-to-transfer first
+        return res.redirect('academies-to-transfer');
+    });
+    
+    // Handle new trust question response
+    router.post('/' + version + '/new-trust-handler', function (req, res) {
+        const isNewTrust = req.session.data['new-trust'];
+        
+        if (isNewTrust === 'yes') {
+            // Always go to proposed trust name if answer is yes
+            res.redirect('incoming-trust-proposed-trust-name');
+        } else {
+            // Always go to preferred trust question if answer is no
+            res.redirect('incoming-trust-preferred-trust-question');
+        }
+    });
+
+    // Handle preferred trust question response
+    router.post('/' + version + '/preferred-trust-handler', function (req, res) {
+        const hasPreferredTrust = req.session.data['preferred-trust'];
+
+        if (hasPreferredTrust === 'yes') {
+            res.redirect('incoming-trust-search');
+        } else {
+            res.redirect('incoming-trust-summary');
+        }
+    });
+
+    // Handle incoming trust search results selection
+    router.post('/' + version + '/incoming-trust-confirmation', function (req, res) {
+        // Get the selected trust value from the form data
+        const selectedTrustValue = req.body['selected-trust'];
+        
+        if (selectedTrustValue) {
+            try {
+                // Parse the JSON string and store temporarily
+                const selectedTrust = JSON.parse(selectedTrustValue);
+                req.session.data['temp-selected-trust'] = selectedTrustValue;
+                req.session.data.tempSelectedTrust = selectedTrust;
+                
+                // Render with the parsed trust data
+                res.render(version + '/incoming-trust-confirmation', {
+                    selectedTrust: selectedTrust
+                });
+            } catch (error) {
+                console.error('Error parsing selected trust:', error);
+                res.render(version + '/incoming-trust-confirmation', {
+                    selectedTrust: null
+                });
+            }
+        } else {
+            res.render(version + '/incoming-trust-confirmation', {
+                selectedTrust: null
+            });
+        }
+    });
+
+    // Handle incoming trust confirmation
+    router.post('/' + version + '/incoming-trust-confirmation-handler', function (req, res) {
+        const confirmTrust = req.body['confirm-trust'];
+        
+        if (confirmTrust === 'yes') {
+            // Only save the trust selection permanently if user confirms with "Yes"
+            req.session.data['selected-trust'] = req.session.data['temp-selected-trust'];
+            req.session.data.selectedTrust = req.session.data.tempSelectedTrust;
+        }
+        
+        // Clear the temporary data
+        delete req.session.data['temp-selected-trust'];
+        delete req.session.data.tempSelectedTrust;
+        
+        res.redirect('incoming-trust-summary');
+    });
+
+    // Handle proposed trust name submission
+    router.post('/' + version + '/proposed-trust-name-handler', function (req, res) {
+        
+        // Store the proposed trust name
+        req.session.data['proposed-trust-name'] = req.body['proposed-trust-name'];
+
+        res.redirect('incoming-trust-summary');
+
+    });
+
+    // Handle the confirm delete page parameters
+    router.get('/' + version + '/confirm-delete-academy', function (req, res) {
+        req.session.data['index'] = req.query.index;
+        res.render(version + '/confirm-delete-academy');
+    });
+
+    // Handle academy deletion
+    router.post('/' + version + '/delete-academy-handler', function (req, res) {
+        const confirmDelete = req.session.data['confirm-delete'];
+        const academyIndex = req.session.data['academy-index'];
+
+        if (confirmDelete === 'yes' && req.session.data['academies-to-transfer']) {
+            // Get academy name before removing it
+            const academyName = req.session.data['academies-to-transfer'][academyIndex].name;
+            // Remove the academy at the specified index
+            req.session.data['academies-to-transfer'].splice(academyIndex, 1);
+            // Store success message in session
+            req.session.data['academy-removed'] = academyName;
+            // Redirect to GET handler
+            return res.redirect('academies-to-transfer');
+        }
+
+        res.redirect('academies-to-transfer');
+    });
+
+    // GET handler for academies-to-transfer page
+    router.get('/' + version + '/academies-to-transfer', function (req, res) {
+        // Check if we have a success message
+        const removedAcademy = req.session.data['academy-removed'];
+        // Clear it from session immediately
+        delete req.session.data['academy-removed'];
+        
+        // Process task owners
+        let taskOwnerDisplay = 'Task owner: not assigned';
+        if (req.session.data.taskOwners?.academies) {
+            const owners = Array.isArray(req.session.data.taskOwners.academies) 
+                ? req.session.data.taskOwners.academies 
+                : [req.session.data.taskOwners.academies];
+            
+            if (owners.length > 0 && !owners.includes('_unchecked')) {
+                taskOwnerDisplay = 'Assigned to: ' + owners.map(owner => {
+                    const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                    return contributor ? contributor.name : owner;
+                }).join(', ');
+            }
+        }
+        
+        res.render(version + '/academies-to-transfer-summary', {
+            success: !!removedAcademy,
+            removedAcademy: removedAcademy,
+            data: req.session.data,
+            taskOwnerDisplay: taskOwnerDisplay
+        });
+    });
+
+    router.get('/' + version + '/s-p', function (req, res) {
+        var school = req.session.data['school-list'].find(x => x.schoolID == req.query.id)
+        req.session.data.currentSchool = school;
+        res.redirect('school-portal-single');
+    })
+
+    // Handle application submission
+    router.post('/' + version + '/application-complete', function (req, res) {
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        if (application) {
+            // Update the application status in both data file and session
+            application.status = "Submitted";
+            application.dateSubmitted = new Date().toLocaleDateString('en-GB');
+            
+            // Update the application details
+            application.academies = req.session.data['academies-to-transfer'] || [];
+            application.trustDetails = req.session.data['new-trust'] === 'yes' 
+                ? { type: 'New trust', name: req.session.data['proposed-trust-name'] }
+                : { type: 'Existing trust', details: req.session.data.selectedTrust };
+            
+            // Update the application in session data
+            if (req.session.data['applications']) {
+                const sessionApp = req.session.data['applications'].find(app => app.reference === ref);
+                if (sessionApp) {
+                    sessionApp.status = "Submitted";
+                    sessionApp.dateSubmitted = application.dateSubmitted;
+                    sessionApp.academies = application.academies;
+                    sessionApp.trustDetails = application.trustDetails;
+                }
+            }
+
+            // Update the main application object in session
+            req.session.data.application.status = "Submitted";
+            req.session.data.application.dateSubmitted = application.dateSubmitted;
+        }
+        
+        res.render(version + '/application-complete', {
+            refNumber: ref
+        });
+    });
+
+    // Handle finance trust page
+    router.post('/' + version + '/create-new-project-stage-3-finance-how-to-finance-trust-handler', function (req, res) {
+        
+        // Store the answer
+        req.session.data['how-to-finance-trust'] = req.body['how-to-finance-trust'];
+
+        res.redirect('finance-summary');
+    });
+
+    // Handle finance approach page
+    router.post('/' + version + '/create-new-project-stage-3-finance-how-to-finance-approach-handler', function (req, res) {
+        
+        // Store the answer
+        req.session.data['how-to-finance-approach'] = req.body['how-to-finance-approach'];
+        
+        res.redirect('finance-summary');
+    });
+
+    // GET handler for application task list
+    router.get('/' + version + '/application-task-list', function (req, res) {
+        const ref = req.query.ref;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Reset new-application-started flag when users arrive at application task list
+        // This indicates they have left the upfront question (contributors-home)
+        if (req.session.data['new-application-started']) {
+            req.session.data['new-application-started'] = false;
+        }
+        
+        if (application) {
+            // Only initialize application data if it doesn't exist in session
+            if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: application.reference,
+                leadApplicant: application.leadApplicant,
+                contributors: application.contributors || []
+            };
+            }
+            
+            // Only initialize task owners if they don't exist in session
+            if (!req.session.data.taskOwners) {
+            req.session.data.taskOwners = application.taskOwners || {};
+            }
+            
+            // Only initialize contributors if they don't exist in session
+            if (!req.session.data['contributors']) {
+            req.session.data['contributors'] = application.contributors || [];
+            }
+            
+            // Only initialize status flags if they don't exist in session
+            if (req.session.data['academies-to-transfer-status'] === undefined) {
+            req.session.data['academies-to-transfer-status'] = application['academies-to-transfer-status'] || false;
+            }
+            if (req.session.data['incoming-trust-status'] === undefined) {
+            req.session.data['incoming-trust-status'] = application['incoming-trust-status'] || false;
+            }
+            if (req.session.data['finance-status'] === undefined) {
+            req.session.data['finance-status'] = application['finance-status'] || false;
+            }
+        }
+        
+        // Process task owners for each task
+        const processTaskOwnerDisplay = (taskKey) => {
+            // Map task keys to their corresponding task owner fields
+            const taskOwnerMap = {
+                'academies-to-transfer': 'academies',
+                'incoming-trust': 'incomingTrust',
+                'finance': 'finance',
+                'declaration': 'declaration',
+                'risks': 'risks',
+                'reason-and-benefits-academies': 'reason-and-benefits-academies',
+                'reason-and-benefits-trust': 'reason-and-benefits-trust',
+                'risks-status': 'risks',
+                'reason-and-benefits-academies-status': 'reason-and-benefits-academies',
+                'reason-and-benefits-trust-status': 'reason-and-benefits-trust',
+                'school-improvement': 'school-improvement',
+                'school-improvement-status': 'school-improvement',
+                'high-quality-and-inclusive-education-status': 'high-quality-and-inclusive-education'
+            };
+            
+            const taskOwnerField = taskOwnerMap[taskKey];
+            const taskOwners = req.session.data.taskOwners?.[taskOwnerField];
+            
+            if (!taskOwners) {
+                return 'Task owner: not assigned';
+            }
+            
+            const owners = Array.isArray(taskOwners) ? taskOwners : [taskOwners];
+            if (owners.length === 0 || owners.includes('_unchecked')) {
+                return 'Task owner: not assigned';
+            }
+            
+            const ownerNames = owners.map(owner => {
+                const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                return contributor ? contributor.name : owner;
+            });
+            
+            return 'Assigned to: ' + ownerNames.join(', ');
+        };
+        
+        res.render(version + '/application-task-list', {
+            data: req.session.data,
+            application: application,
+            processTaskOwners: processTaskOwnerDisplay
+        });
+    });
+
+    // GET handler for new trust question
+    router.get('/' + version + '/incoming-trust-new-trust-question', function (req, res) {
+        res.render(version + '/incoming-trust-new-trust-question', {
+            data: req.session.data
+        });
+    });
+
+    // GET handler for preferred trust question
+    router.get('/' + version + '/incoming-trust-preferred-trust-question', function (req, res) {
+        res.render(version + '/incoming-trust-preferred-trust-question', {
+            data: req.session.data
+        });
+    });
+
+    // Handle incoming trust summary
+    router.post('/' + version + '/incoming-trust-summary-handler', function (req, res) {
+        // Save the checkbox state - using 'Complete' to match the form value
+        req.session.data['incoming-trust-status'] = req.body['incoming-trust-status'] === 'Complete';
+        
+        // Go to application task list
+        return res.redirect('application-task-list');
+    });
+    
+
+    // GET handler for dashboard
+    router.get('/' + version + '/dashboard', function (req, res) {
+        // Find the new application if it exists in session or data file
+        let newApplication = null;
+        if (req.session.data['applications']) {
+            newApplication = req.session.data['applications'].find(app => app.reference === '240315-ABC34');
+        }
+        // If not in session, check data file only if there's an active application session
+        if (!newApplication && req.session.data.application && req.session.data.application.reference === '240315-ABC34') {
+            newApplication = data.applications.find(app => app.reference === '240315-ABC34');
+        }
+        
+        // Find the contributor application
+        let contributorApplication = null;
+        if (req.session.data['applications']) {
+            contributorApplication = req.session.data['applications'].find(app => app.reference === '240315-XYZ45');
+        }
+        // If not in session, check data file
+        if (!contributorApplication) {
+            contributorApplication = data.applications.find(app => app.reference === '240315-XYZ45');
+        }
+        
+        res.render(version + '/dashboard', {
+            data: req.session.data,
+            newApplication: newApplication,
+            contributorApplication: contributorApplication
+        });
+    });
+
+    // POST handler for new application creation
+    router.post('/' + version + '/application-task-list', function (req, res) {
+        const ref = req.query.ref;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        if (application) {
+            // Reset the application status in data file
+            application.status = "Not submitted yet";
+            delete application.dateSubmitted;
+            
+            // Set new-application-started flag
+            req.session.data['new-application-started'] = true;
+            
+            // Initialize application data with reset status
+            req.session.data.application = {
+                reference: application.reference,
+                leadApplicant: application.leadApplicant,
+                contributors: application.contributors || []
+            };
+            
+            // Initialize task owners
+            req.session.data.taskOwners = application.taskOwners || {};
+            
+            // Initialize contributors
+            req.session.data['contributors'] = application.contributors || [];
+            
+            // Initialize status flags
+            req.session.data['academies-to-transfer-status'] = application['academies-to-transfer-status'] || false;
+            req.session.data['incoming-trust-status'] = application['incoming-trust-status'] || false;
+            req.session.data['finance-status'] = application['finance-status'] || false;
+            
+            // Initialize applications array in session if it doesn't exist
+            if (!req.session.data['applications']) {
+                req.session.data['applications'] = [];
+            }
+            
+            // Add the application to session applications immediately
+            req.session.data['applications'].push({
+                ...application,
+                status: "Not submitted yet"
+            });
+        }
+        
+        // Redirect based on whether this is a new application or a form submission
+        if (req.session.data['new-application-started']) {
+            res.redirect('contributors-home');
+        } else {
+            res.redirect('application-task-list?ref=' + ref);
+        }
+    });
+
+    // GET handler for contributors-home
+    router.get('/' + version + '/contributors-home', function (req, res) {
+        // Initialize application data if not exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'],
+                contributors: []
+            };
+        }
+
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        if (application) {
+            // Only initialize contributors from data file if they don't exist in session
+            if (!req.session.data['contributors']) {
+                req.session.data['contributors'] = [...(application.contributors || [])];
+            }
+            
+            // Update application reference and lead applicant in session
+            req.session.data.application = {
+                reference: application.reference,
+                leadApplicant: application.leadApplicant,
+                contributors: req.session.data['contributors']
+            };
+            
+            // Initialize applications array in session if it doesn't exist
+            if (!req.session.data['applications']) {
+                req.session.data['applications'] = [];
+            }
+            
+            // Add application to session applications if it doesn't exist
+            const sessionApp = req.session.data['applications'].find(app => app.reference === ref);
+            if (!sessionApp) {
+                req.session.data['applications'].push({
+                    ...application,
+                    status: "Not submitted yet"
+                });
+            }
+        }
+        
+        res.render(version + '/contributors-home', {
+            data: req.session.data
+        });
+    });
+
+    // GET handler for contributor invite page
+    router.get('/' + version + '/contributor-invite', function (req, res) {
+        res.render(version + '/contributor-invite', {
+            data: req.session.data
+        });
+    });
+
+    // POST handler for contributor invite form
+    router.post('/' + version + '/contributor-invite-handler', function (req, res) {
+        const email = req.body['contributor-email'];
+        const ref = req.session.data.application.reference;
+        
+        // Find the application in the data file
+        const application = data.applications.find(app => app.reference === ref);
+        
+        if (application) {
+            // Initialize contributors array in session if it doesn't exist
+            if (!req.session.data['contributors']) {
+                // Start with the pre-existing contributors from the data file
+                req.session.data['contributors'] = [...(application.contributors || [])];
+            }
+            
+            // Add the new contributor to session data only
+            const newContributor = {
+                email: email,
+                name: email.split('@')[0].replace('.', ' ').replace(/([A-Z])/g, ' $1').trim() // Generate name from email
+            };
+            req.session.data['contributors'].push(newContributor);
+            
+            // Update the application data in session
+            req.session.data.application = {
+                reference: application.reference,
+                contributors: req.session.data['contributors']
+            };
+        }
+        
+        // Redirect back to contributors home
+        res.redirect('contributors-home');
+    });
+
+    // Handle task owner update
+    router.post('/' + version + '/task-owner-update-handler', function (req, res) {
+        const task = req.query.task;
+        const selectedOwners = req.body['task-owner'];
+        
+        // Initialize taskOwners in session if it doesn't exist
+        if (!req.session.data.taskOwners) {
+            req.session.data.taskOwners = {};
+            }
+            
+            // Store the selected owners as an array, filtering out any undefined or null values
+            if (selectedOwners) {
+            req.session.data.taskOwners[task] = Array.isArray(selectedOwners) 
+                    ? selectedOwners.filter(owner => owner && owner !== '_unchecked')
+                    : [selectedOwners];
+            } else {
+            req.session.data.taskOwners[task] = [];
+        }
+        
+        // Redirect to the appropriate summary page based on the task
+        let redirectUrl;
+        switch (task) {
+            case 'academies':
+                redirectUrl = 'academies-to-transfer-summary';
+                break;
+            case 'incomingTrust':
+                redirectUrl = 'incoming-trust-summary';
+                break;
+            case 'finance':
+                redirectUrl = 'finance-summary';
+                break;
+            case 'declaration':
+                redirectUrl = 'declaration-summary';
+                break;
+            case 'risks':
+                redirectUrl = 'risks-summary';
+                break;
+            case 'reason-and-benefits-academies':
+                redirectUrl = 'reason-and-benefits-academies';
+                break;
+            case 'reason-and-benefits-trust':
+                redirectUrl = 'reason-and-benefits-trust';
+                break;
+            case 'school-improvement':
+                redirectUrl = 'school-improvement';
+                break;
+            case 'high-quality-and-inclusive-education':
+                redirectUrl = 'high-quality-and-inclusive-education';
+                break;
+            default:
+                redirectUrl = 'application-task-list?ref=' + req.session.data.application.reference;
+        }
+        
+        res.redirect('/' + version + '/' + redirectUrl);
+    });
+
+    // GET handler for task owner update page
+    router.get('/' + version + '/task-owner-update', function (req, res) {
+        const task = req.query.task;
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Get current task owners' emails
+        let currentTaskOwnerEmails = [];
+        if (req.session.data.taskOwners && req.session.data.taskOwners[task]) {
+            currentTaskOwnerEmails = Array.isArray(req.session.data.taskOwners[task]) 
+                ? req.session.data.taskOwners[task] 
+                : [req.session.data.taskOwners[task]];
+        }
+        
+        // Prepare checkbox items from session contributors
+        const checkboxItems = [];
+        if (req.session.data['contributors']) {
+            checkboxItems.push(...req.session.data['contributors'].map(contributor => ({
+                value: contributor.email,
+                text: contributor.name,
+                hint: {
+                    text: contributor.email
+                },
+                checked: currentTaskOwnerEmails.includes(contributor.email)
+            })));
+        }
+
+        // Get current task owners' names for display
+        const currentTaskOwners = processTaskOwners(
+            req.session.data.taskOwners?.[task],
+            req.session.data['contributors'] || []
+        );
+        
+        res.render(version + '/task-owner-update', {
+            data: req.session.data,
+            task: task,
+            checkboxItems: checkboxItems,
+            currentTaskOwners: currentTaskOwners,
+            currentTaskOwnerEmails: currentTaskOwnerEmails
+        });
+    });
+
+    // Helper function to process task owners
+    function processTaskOwners(taskOwners, contributors) {
+        if (!taskOwners) return 'Task owner: not assigned';
+        
+        const owners = Array.isArray(taskOwners) ? taskOwners : [taskOwners];
+        if (owners.length === 0) return 'Task owner: not assigned';
+        
+        return owners.map(owner => {
+            const contributor = contributors.find(c => c.email === owner);
+            return contributor ? contributor.name : owner;
+        }).join(', ');
+    }
+
+    // GET handler for academies to transfer summary
+    router.get('/' + version + '/academies-to-transfer-summary', function (req, res) {
+        // Initialize application data if not exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'],
+                contributors: []
+            };
+        }
+
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Process task owners
+        let taskOwnerDisplay = 'Task owner: not assigned';
+        if (req.session.data.taskOwners?.academies) {
+            const owners = Array.isArray(req.session.data.taskOwners.academies) 
+                ? req.session.data.taskOwners.academies 
+                : [req.session.data.taskOwners.academies];
+            
+            if (owners.length > 0 && !owners.includes('_unchecked')) {
+                taskOwnerDisplay = 'Assigned to: ' + owners.map(owner => {
+                    const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                    return contributor ? contributor.name : owner;
+                }).join(', ');
+            }
+        }
+
+        // If the application has pre-populated academies in the data file, look up their full details
+        if (application && application['academies-to-transfer']) {
+            req.session.data['academies-to-transfer'] = application['academies-to-transfer'].map(urn => {
+                const academy = data.academies.find(a => a.urn === urn);
+                return academy || { urn }; // Return full academy details if found, or just URN if not found
+            });
+        }
+        
+        res.render(version + '/academies-to-transfer-summary', {
+            data: req.session.data,
+            taskOwnerDisplay: taskOwnerDisplay
+        });
+    });
+
+    // GET handler for incoming trust summary
+    router.get('/' + version + '/incoming-trust-summary', function (req, res) {
+        // Initialize application data if not exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'],
+                contributors: []
+            };
+        }
+
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Process task owners
+        let taskOwnerDisplay = 'Task owner: not assigned';
+        if (req.session.data.taskOwners?.incomingTrust) {
+            const owners = Array.isArray(req.session.data.taskOwners.incomingTrust) 
+                ? req.session.data.taskOwners.incomingTrust 
+                : [req.session.data.taskOwners.incomingTrust];
+            
+            if (owners.length > 0 && !owners.includes('_unchecked')) {
+                taskOwnerDisplay = 'Assigned to: ' + owners.map(owner => {
+                    const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                    return contributor ? contributor.name : owner;
+                }).join(', ');
+            }
+        }
+        
+        res.render(version + '/incoming-trust-summary', {
+            data: req.session.data,
+            taskOwnerDisplay: taskOwnerDisplay
+        });
+    });
+
+    // GET handler for finance summary
+    router.get('/' + version + '/finance-summary', function (req, res) {
+        // Initialize application data if not exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'],
+                contributors: []
+            };
+        }
+
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Process task owners
+        let taskOwnerDisplay = 'Task owner: not assigned';
+        if (req.session.data.taskOwners?.finance) {
+            const owners = Array.isArray(req.session.data.taskOwners.finance) 
+                ? req.session.data.taskOwners.finance 
+                : [req.session.data.taskOwners.finance];
+            
+            if (owners.length > 0 && !owners.includes('_unchecked')) {
+                taskOwnerDisplay = 'Assigned to: ' + owners.map(owner => {
+                    const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                    return contributor ? contributor.name : owner;
+                }).join(', ');
+            }
+        }
+        
+        res.render(version + '/finance-summary', {
+            data: req.session.data,
+            taskOwnerDisplay: taskOwnerDisplay
+        });
+    });
+
+    // GET handler for risks summary
+    router.get('/' + version + '/risks-summary', function (req, res) {
+        // Initialize application data if not exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'],
+                contributors: []
+            };
+        }
+
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Process task owners
+        let taskOwnerDisplay = 'Task owner: not assigned';
+        if (req.session.data.taskOwners?.risks) {
+            const owners = Array.isArray(req.session.data.taskOwners.risks) 
+                ? req.session.data.taskOwners.risks 
+                : [req.session.data.taskOwners.risks];
+            
+            if (owners.length > 0 && !owners.includes('_unchecked')) {
+                taskOwnerDisplay = 'Assigned to: ' + owners.map(owner => {
+                    const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                    return contributor ? contributor.name : owner;
+                }).join(', ');
+            }
+        }
+        
+        res.render(version + '/risks-summary', {
+            data: req.session.data,
+            taskOwnerDisplay: taskOwnerDisplay
+        });
+    });
+
+    // POST handler for risks summary
+    router.post('/' + version + '/risks-summary', function (req, res) {
+        // Check if this is the due diligence form submission
+        if (req.body['risks-due-diligence']) {
+            // Save the due diligence data to session
+            req.session.data['risks-due-diligence'] = req.body['risks-due-diligence'];
+            
+            // Redirect to the risks summary page (GET)
+            return res.redirect('risks-summary');
+        }
+        
+        // Check if this is the pupil numbers form submission
+        if (req.body['risks-pupil-numbers']) {
+            // Save the pupil numbers data to session
+            req.session.data['risks-pupil-numbers'] = req.body['risks-pupil-numbers'];
+            
+            // If the answer is "No", clear any existing pupil forecast data and go to summary
+            if (req.body['risks-pupil-numbers'] === 'No') {
+                req.session.data['risks-pupil-forecast'] = '';
+                return res.redirect('risks-summary');
+            }
+            
+            // If the answer is "Yes", go to the forecast question
+            if (req.body['risks-pupil-numbers'] === 'Yes') {
+                return res.redirect('risks-pupil-forecast');
+            }
+        }
+        
+        // Check if this is the pupil forecast form submission
+        if (req.body['risks-pupil-forecast']) {
+            // Save the pupil forecast data to session
+            req.session.data['risks-pupil-forecast'] = req.body['risks-pupil-forecast'];
+            
+            // Redirect to the risks summary page (GET)
+            return res.redirect('risks-summary');
+        }
+        
+        // Check if this is the financial deficit form submission
+        if (req.body['risks-financial-deficit']) {
+            // Save the financial deficit data to session
+            req.session.data['risks-financial-deficit'] = req.body['risks-financial-deficit'];
+            
+            // If the answer is "No", clear any existing financial forecast data and go to summary
+            if (req.body['risks-financial-deficit'] === 'No') {
+                req.session.data['risks-financial-forecast'] = '';
+                return res.redirect('risks-summary');
+            }
+            
+            // If the answer is "Yes", go to the financial forecast question
+            if (req.body['risks-financial-deficit'] === 'Yes') {
+                return res.redirect('risks-financial-forecast');
+            }
+        }
+        
+        // Check if this is the financial forecast form submission
+        if (req.body['risks-financial-forecast']) {
+            // Save the financial forecast data to session
+            req.session.data['risks-financial-forecast'] = req.body['risks-financial-forecast'];
+            
+            // Redirect to the risks summary page (GET)
+            return res.redirect('risks-summary');
+        }
+        
+        // Check if this is the finances pooled form submission
+        if (req.body['risks-finances-pooled']) {
+            // Save the finances pooled data to session
+            req.session.data['risks-finances-pooled'] = req.body['risks-finances-pooled'];
+            
+            // If the answer is "No", clear any existing reserves transfer data and go to summary
+            if (req.body['risks-finances-pooled'] === 'No') {
+                req.session.data['risks-reserves-transfer'] = '';
+                return res.redirect('risks-summary');
+            }
+            
+            // If the answer is "Yes", go to the reserves transfer question
+            if (req.body['risks-finances-pooled'] === 'Yes') {
+                return res.redirect('risks-reserves-transfer');
+            }
+        }
+        
+        // Check if this is the reserves transfer form submission
+        if (req.body['risks-reserves-transfer']) {
+            // Save the reserves transfer data to session
+            req.session.data['risks-reserves-transfer'] = req.body['risks-reserves-transfer'];
+            
+            // Redirect to the risks summary page (GET)
+            return res.redirect('risks-summary');
+        }
+        
+        // Check if this is the other risks form submission
+        if (req.body['risks-other-risks']) {
+            // Save the other risks data to session
+            req.session.data['risks-other-risks'] = req.body['risks-other-risks'];
+            
+            // If the answer is "No", clear any existing risk management data and go to summary
+            if (req.body['risks-other-risks'] === 'No') {
+                req.session.data['risks-risk-management'] = '';
+                return res.redirect('risks-summary');
+            }
+            
+            // If the answer is "Yes", go to the risk management question
+            if (req.body['risks-other-risks'] === 'Yes') {
+                return res.redirect('risks-risk-management');
+            }
+        }
+        
+        // Check if this is the risk management form submission
+        if (req.body['risks-risk-management']) {
+            // Save the risk management data to session
+            req.session.data['risks-risk-management'] = req.body['risks-risk-management'];
+            
+            // Redirect to the risks summary page (GET)
+            return res.redirect('risks-summary');
+        }
+        
+        // Check if this is the completion checkbox form submission
+        if (req.body['risks-status']) {
+            // Save the checkbox state - using 'Complete' to match the form value
+            req.session.data['risks-status'] = req.body['risks-status'] === 'Complete';
+            
+            // Go to application task list
+            return res.redirect('application-task-list');
+        }
+        
+        // Default fallback
+        return res.redirect('risks-summary');
+    });
+
+    // POST handler for risks due diligence
+    router.post('/' + version + '/risks-due-diligence', function (req, res) {
+        // Save the due diligence data to session
+        req.session.data['risks-due-diligence'] = req.body['risks-due-diligence'];
+        
+        // Redirect to the risks summary page
+        res.redirect('risks-summary');
+    });
+
+    // GET handler for reason and benefits academies
+    router.get('/' + version + '/reason-and-benefits-academies', function (req, res) {
+        // Initialize application data if not exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'],
+                contributors: []
+            };
+        }
+
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Process task owners
+        let taskOwnerDisplay = 'Task owner: not assigned';
+        if (req.session.data.taskOwners?.['reason-and-benefits-academies']) {
+            const owners = Array.isArray(req.session.data.taskOwners['reason-and-benefits-academies']) 
+                ? req.session.data.taskOwners['reason-and-benefits-academies'] 
+                : [req.session.data.taskOwners['reason-and-benefits-academies']];
+            
+            if (owners.length > 0 && !owners.includes('_unchecked')) {
+                taskOwnerDisplay = 'Assigned to: ' + owners.map(owner => {
+                    const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                    return contributor ? contributor.name : owner;
+                }).join(', ');
+            }
+        }
+        
+        res.render(version + '/reason-and-benefits-academies', {
+            data: req.session.data,
+            taskOwnerDisplay: taskOwnerDisplay
+        });
+    });
+
+    // POST handler for reason and benefits academies strategic needs
+    router.post('/' + version + '/reason-and-benefits-academies-summary', function (req, res) {
+        // Save the strategic needs data to session
+        req.session.data['reason-and-benefits-academies-strategic-needs'] = req.body['reason-and-benefits-academies-strategic-needs'];
+        
+        // Redirect to the reason and benefits academies summary page
+        res.redirect('reason-and-benefits-academies');
+    });
+
+    // POST handler for reason and benefits academies maintain improve
+    router.post('/' + version + '/reason-and-benefits-academies-maintain-improve-handler', function (req, res) {
+        // Save the maintain improve data to session
+        req.session.data['reason-and-benefits-academies-maintain-improve'] = req.body['reason-and-benefits-academies-maintain-improve'];
+        
+        // Redirect to the reason and benefits academies summary page
+        res.redirect('reason-and-benefits-academies');
+    });
+
+    // POST handler for reason and benefits academies benefit trust
+    router.post('/' + version + '/reason-and-benefits-academies-benefit-trust-handler', function (req, res) {
+        // Save the benefit trust data to session
+        req.session.data['reason-and-benefits-academies-benefit-trust'] = req.body['reason-and-benefits-academies-benefit-trust'];
+        
+        // Redirect to the reason and benefits academies summary page
+        res.redirect('reason-and-benefits-academies');
+    });
+
+    // GET handler for reason and benefits trust
+    router.get('/' + version + '/reason-and-benefits-trust', function (req, res) {
+        // Initialize application data if not exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'],
+                contributors: []
+            };
+        }
+
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Process task owners
+        let taskOwnerDisplay = 'Task owner: not assigned';
+        if (req.session.data.taskOwners?.['reason-and-benefits-trust']) {
+            const owners = Array.isArray(req.session.data.taskOwners['reason-and-benefits-trust']) 
+                ? req.session.data.taskOwners['reason-and-benefits-trust'] 
+                : [req.session.data.taskOwners['reason-and-benefits-trust']];
+            
+            if (owners.length > 0 && !owners.includes('_unchecked')) {
+                taskOwnerDisplay = 'Assigned to: ' + owners.map(owner => {
+                    const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                    return contributor ? contributor.name : owner;
+                }).join(', ');
+            }
+        }
+        
+        res.render(version + '/reason-and-benefits-trust', {
+            data: req.session.data,
+            taskOwnerDisplay: taskOwnerDisplay
+        });
+    });
+
+    // POST handler for reason and benefits trust strategic needs
+    router.post('/' + version + '/reason-and-benefits-trust-strategic-needs-handler', function (req, res) {
+        // Save the strategic needs data to session
+        req.session.data['reason-and-benefits-trust-strategic-needs'] = req.body['reason-and-benefits-trust-strategic-needs'];
+        
+        // Redirect to the reason and benefits trust summary page
+        res.redirect('reason-and-benefits-trust');
+    });
+
+    // POST handler for reason and benefits trust maintain improve
+    router.post('/' + version + '/reason-and-benefits-trust-maintain-improve-handler', function (req, res) {
+        // Save the maintain improve data to session
+        req.session.data['reason-and-benefits-trust-maintain-improve'] = req.body['reason-and-benefits-trust-maintain-improve'];
+        
+        // Redirect to the reason and benefits trust summary page
+        res.redirect('reason-and-benefits-trust');
+    });
+
+    // POST handler for reason and benefits trust transfer type
+    router.post('/' + version + '/reason-and-benefits-trust-transfer-type-handler', function (req, res) {
+        // Save the transfer type data to session
+        req.session.data['reason-and-benefits-trust-transfer-type'] = req.body['reason-and-benefits-trust-transfer-type'];
+        
+        // Redirect to the reason and benefits trust summary page
+        res.redirect('reason-and-benefits-trust');
+    });
+
+    // POST handler for high-quality and inclusive education quality
+    router.post('/' + version + '/high-quality-and-inclusive-education-quality-handler', function (req, res) {
+        // Save the quality data to session
+        req.session.data['high-quality-and-inclusive-education-quality'] = req.body['high-quality-and-inclusive-education-quality'];
+        
+        // Redirect to the high-quality and inclusive education summary page
+        res.redirect('high-quality-and-inclusive-education');
+    });
+
+    // POST handler for high-quality and inclusive education inclusive
+    router.post('/' + version + '/high-quality-and-inclusive-education-inclusive-handler', function (req, res) {
+        // Save the inclusive data to session
+        req.session.data['high-quality-and-inclusive-education-inclusive'] = req.body['high-quality-and-inclusive-education-inclusive'];
+        
+        // Redirect to the high-quality and inclusive education summary page
+        res.redirect('high-quality-and-inclusive-education');
+    });
+
+    // GET handler for high-quality and inclusive education summary
+    router.get('/' + version + '/high-quality-and-inclusive-education', function (req, res) {
+        // Initialize application data if not exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'],
+                contributors: []
+            };
+        }
+
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Load contributors from application data if not already in session
+        if (application && application.contributors && (!req.session.data['contributors'] || req.session.data['contributors'].length === 0)) {
+            req.session.data['contributors'] = application.contributors;
+        }
+        
+        // Process task owners
+        let taskOwnerDisplay = 'Task owner: not assigned';
+        if (req.session.data.taskOwners?.['high-quality-and-inclusive-education']) {
+            const owners = Array.isArray(req.session.data.taskOwners['high-quality-and-inclusive-education']) 
+                ? req.session.data.taskOwners['high-quality-and-inclusive-education'] 
+                : [req.session.data.taskOwners['high-quality-and-inclusive-education']];
+            
+            if (owners.length > 0 && !owners.includes('_unchecked')) {
+                taskOwnerDisplay = 'Assigned to: ' + owners.map(owner => {
+                    const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                    return contributor ? contributor.name : owner;
+                }).join(', ');
+            }
+        }
+        
+        res.render(version + '/high-quality-and-inclusive-education', {
+            data: req.session.data,
+            taskOwnerDisplay: taskOwnerDisplay
+        });
+    });
+
+    // GET handler for school improvement
+    router.get('/' + version + '/school-improvement', function (req, res) {
+        // Initialize application data if not exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'],
+                contributors: []
+            };
+        }
+
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Load contributors from application data if not already in session
+        if (application && application.contributors && (!req.session.data['contributors'] || req.session.data['contributors'].length === 0)) {
+            req.session.data['contributors'] = application.contributors;
+        }
+        
+        // Process task owners
+        let taskOwnerDisplay = 'Task owner: not assigned';
+        if (req.session.data.taskOwners?.['school-improvement']) {
+            const owners = Array.isArray(req.session.data.taskOwners['school-improvement']) 
+                ? req.session.data.taskOwners['school-improvement'] 
+                : [req.session.data.taskOwners['school-improvement']];
+            
+            if (owners.length > 0 && !owners.includes('_unchecked')) {
+                taskOwnerDisplay = 'Assigned to: ' + owners.map(owner => {
+                    const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                    return contributor ? contributor.name : owner;
+                }).join(', ');
+            }
+        }
+        
+        res.render(version + '/school-improvement', {
+            data: req.session.data,
+            taskOwnerDisplay: taskOwnerDisplay
+        });
+    });
+
+    // POST handler for school improvement model
+    router.post('/' + version + '/school-improvement-model-handler', function (req, res) {
+        // Save the school improvement model data to session
+        req.session.data['school-improvement-model'] = req.body['school-improvement-model'];
+        
+        // Redirect to the school improvement summary page
+        res.redirect('school-improvement');
+    });
+
+    // GET handler for governance structure
+    router.get('/' + version + '/governance-structure', function (req, res) {
+        // Initialize application data if not exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'],
+                contributors: []
+            };
+        }
+
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Load contributors from application data if not already in session
+        if (application && application.contributors && (!req.session.data['contributors'] || req.session.data['contributors'].length === 0)) {
+            req.session.data['contributors'] = application.contributors;
+        }
+        
+        // Process task owners
+        let taskOwnerDisplay = 'Task owner: not assigned';
+        if (req.session.data.taskOwners?.['governance-structure']) {
+            const owners = Array.isArray(req.session.data.taskOwners['governance-structure']) 
+                ? req.session.data.taskOwners['governance-structure'] 
+                : [req.session.data.taskOwners['governance-structure']];
+            
+            if (owners.length > 0 && !owners.includes('_unchecked')) {
+                taskOwnerDisplay = 'Assigned to: ' + owners.map(owner => {
+                    const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                    return contributor ? contributor.name : owner;
+                }).join(', ');
+            }
+        }
+        
+        res.render(version + '/governance-structure', {
+            data: req.session.data,
+            taskOwnerDisplay: taskOwnerDisplay
+        });
+    });
+
+    // POST handler for governance structure model
+    router.post('/' + version + '/governance-structure-model-handler', function (req, res) {
+        // Handle file upload for governance structure
+        if (req.files && req.files['governance-structure-file']) {
+            const uploadedFile = req.files['governance-structure-file'];
+            
+            // Initialize files array if it doesn't exist
+            if (!req.session.data['governance-structure-files']) {
+                req.session.data['governance-structure-files'] = [];
+            }
+            
+            // Add the new file to the array
+            req.session.data['governance-structure-files'].push({
+                name: uploadedFile.name,
+                size: uploadedFile.size,
+                type: uploadedFile.mimetype
+            });
+            
+            // Set success flag for banner
+            req.session.data['file-upload-success'] = true;
+            
+            // Clear deletion success flag
+            req.session.data['file-delete-success'] = false;
+            delete req.session.data['deleted-file-name'];
+            
+            // In a real application, you would save the file to a secure location
+            // For this prototype, we'll just store the file information
+        }
+        
+        // Redirect to the governance structure model page to show the file table
+        res.redirect('governance-structure-model');
+    });
+
+    // POST handler for clearing upload success flag
+    router.post('/' + version + '/clear-upload-success-flag', function (req, res) {
+        req.session.data['file-upload-success'] = false;
+        res.status(200).json({ success: true });
+    });
+
+    // POST handler for clearing delete success flag
+    router.post('/' + version + '/clear-delete-success-flag', function (req, res) {
+        req.session.data['file-delete-success'] = false;
+        delete req.session.data['deleted-file-name'];
+        res.status(200).json({ success: true });
+    });
+
+    // GET handler for downloading governance structure files
+    router.get('/' + version + '/download-governance-file/:index', function (req, res) {
+        const fileIndex = parseInt(req.params.index);
+        
+        if (req.session.data['governance-structure-files'] && req.session.data['governance-structure-files'][fileIndex]) {
+            const file = req.session.data['governance-structure-files'][fileIndex];
+            
+            // Set headers for file download
+            res.setHeader('Content-Type', file.type || 'application/octet-stream');
+            res.setHeader('Content-Disposition', `attachment; filename="${file.name}"`);
+            
+            // For prototype purposes, create a simple text response
+            // In a real application, this would serve the actual file from storage
+            res.send(`This is a prototype file download for: ${file.name}\n\nFile size: ${(file.size / 1024 / 1024).toFixed(2)} MB\nFile type: ${file.type}\n\nThis is a simulated file download for demonstration purposes.`);
+        } else {
+            res.status(404).send('File not found');
+        }
+    });
+
+    // POST handler for deleting governance structure files
+    router.post('/' + version + '/delete-governance-file', function (req, res) {
+        const fileIndex = parseInt(req.body['file-index']);
+        
+        if (req.session.data['governance-structure-files'] && req.session.data['governance-structure-files'][fileIndex]) {
+            // Get the file name before removing it for the success message
+            const deletedFileName = req.session.data['governance-structure-files'][fileIndex].name;
+            
+            // Remove the file at the specified index
+            req.session.data['governance-structure-files'].splice(fileIndex, 1);
+            
+            // Set success flag for deletion banner
+            req.session.data['file-delete-success'] = true;
+            req.session.data['deleted-file-name'] = deletedFileName;
+            
+            // Clear upload success flag
+            req.session.data['file-upload-success'] = false;
+        }
+        
+        // Redirect back to the governance structure model page
+        res.redirect('governance-structure-model');
+    });
+
+    // POST handler for governance team confirmation
+    router.post('/' + version + '/governance-team-confirmation-handler', function (req, res) {
+        // Save the governance team confirmed data to session
+        req.session.data['governance-team-confirmed'] = req.body['governance-team-confirmed'];
+        
+        // If the answer is "No", go to the explanation page
+        if (req.body['governance-team-confirmed'] === 'No') {
+            return res.redirect('governance-team-explanation');
+        }
+        
+        // If the answer is "Yes", go back to the governance structure summary
+        if (req.body['governance-team-confirmed'] === 'Yes') {
+            return res.redirect('governance-structure');
+        }
+        
+        // Default fallback
+        return res.redirect('governance-structure');
+    });
+
+    // POST handler for governance team explanation
+    router.post('/' + version + '/governance-team-explanation', function (req, res) {
+        // Save the governance team explanation data to session
+        req.session.data['governance-team-explanation'] = req.body['governance-team-explanation'];
+        
+        // Redirect to the governance structure summary page
+        res.redirect('governance-structure');
+    });
+
+    // GET handler for governance team explanation
+    router.get('/' + version + '/governance-team-explanation', function (req, res) {
+        res.render(version + '/governance-team-explanation');
+    });
+
+    // GET handler for check your answers
+    router.get('/' + version + '/check-your-answers', function (req, res) {
+        // Ensure application data exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'] || 'Not set',
+                leadApplicant: 'Not set',
+                status: 'Draft'
+            };
+        }
+        
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // If the application has pre-populated academies in the data file, look up their full details
+        if (application && application['academies-to-transfer']) {
+            req.session.data['academies-to-transfer'] = application['academies-to-transfer'].map(urn => {
+                const academy = data.academies.find(a => a.urn === urn);
+                return academy || { urn }; // Return full academy details if found, or just URN if not found
+            });
+        }
+        
+        res.render(version + '/check-your-answers', {
+            data: req.session.data,
+            application: application || req.session.data.application
+        });
+    });
+
+    // Handle declaration trust search results selection
+    router.post('/' + version + '/declaration-trust-confirmation', function (req, res) {
+        // Get the selected trust value from the form data
+        const selectedDeclarationTrustValue = req.body['selected-trust'];
+        
+        if (selectedDeclarationTrustValue) {
+            try {
+                // Parse the JSON string and store temporarily
+                const selectedDeclarationTrust = JSON.parse(selectedDeclarationTrustValue);
+                req.session.data['temp-selected-declaration-trust'] = selectedDeclarationTrustValue;
+                req.session.data.tempSelectedDeclarationTrust = selectedDeclarationTrust;
+                
+                // Prepare the hint HTML in JavaScript to avoid Nunjucks parsing issues
+                const hintHtml = selectedDeclarationTrust ? 
+                    `<div class="govuk-inset-text">
+                        <h2 class="govuk-heading-m">${selectedDeclarationTrust.name}</h2>
+                        <p class="govuk-body">TRN: ${selectedDeclarationTrust.ref}</p>
+                        <p class="govuk-body">UKPRN: ${selectedDeclarationTrust.companies}</p>
+                    </div>` : '';
+                
+                // Render with the parsed trust data and prepared hint HTML
+                res.render(version + '/declaration-trust-confirmation', {
+                    selectedDeclarationTrust: selectedDeclarationTrust,
+                    hintHtml: hintHtml
+                });
+            } catch (error) {
+                console.error('Error parsing selected declaration trust:', error);
+                res.render(version + '/declaration-trust-confirmation', {
+                    selectedDeclarationTrust: null,
+                    hintHtml: ''
+                });
+            }
+        } else {
+            res.render(version + '/declaration-trust-confirmation', {
+                selectedDeclarationTrust: null,
+                hintHtml: ''
+            });
+        }
+    });
+
+    // Handle declaration trust confirmation
+    router.post('/' + version + '/declaration-trust-confirmation-handler', function (req, res) {
+        const confirmTrust = req.body['confirm-trust'];
+        
+        if (confirmTrust === 'yes') {
+            // Only save the trust selection permanently if user confirms with "Yes"
+            req.session.data['selected-declaration-trust'] = req.session.data['temp-selected-declaration-trust'];
+            req.session.data.selectedDeclarationTrust = req.session.data.tempSelectedDeclarationTrust;
+            
+            // Clear the temporary data
+            delete req.session.data['temp-selected-declaration-trust'];
+            delete req.session.data.tempSelectedDeclarationTrust;
+            
+            // Redirect to declaration form when user confirms
+            res.redirect('declaration-form');
+        } else {
+            // Clear the temporary data
+            delete req.session.data['temp-selected-declaration-trust'];
+            delete req.session.data.tempSelectedDeclarationTrust;
+            
+            // Redirect to declaration summary when user says no
+            res.redirect('declaration-summary');
+        }
+    });
+
+    // Handle declaration form submission
+    router.post('/' + version + '/declaration-form-handler', function (req, res) {
+        // Initialize declarations array if it doesn't exist
+        if (!req.session.data['declarations']) {
+            req.session.data['declarations'] = [];
+        }
+        
+        // Create declaration object with complete trust information
+        const declarationData = {
+            trust: {
+                name: req.session.data.selectedDeclarationTrust?.name || '',
+                ref: req.session.data.selectedDeclarationTrust?.ref || '',
+                companies: req.session.data.selectedDeclarationTrust?.companies || ''
+            },
+            chairOfTrustees: req.body['declarationFormChairOfTrustees'] || '',
+            dateOfDeclaration: {
+                day: req.body['passport-issued-day'] || '',
+                month: req.body['passport-issued-month'] || '',
+                year: req.body['passport-issued-year'] || ''
+            },
+            status: 'Signed'
+        };
+        
+        // Check if we're updating an existing declaration
+        const declarationIndex = req.body['declaration-index'];
+        const trustName = req.session.data.selectedDeclarationTrust?.name;
+        
+        if (declarationIndex !== undefined && req.session.data['declarations'][declarationIndex]) {
+            // Update existing declaration by index
+            req.session.data['declarations'][declarationIndex] = declarationData;
+        } else if (trustName && req.session.data['declarations']) {
+            // Try to find existing declaration by trust name
+            const existingIndex = req.session.data['declarations'].findIndex(declaration => 
+                declaration.trust.name === trustName
+            );
+            
+            if (existingIndex !== -1) {
+                // Update existing declaration
+                req.session.data['declarations'][existingIndex] = declarationData;
+            } else {
+                // Add new declaration to the array
+                req.session.data['declarations'].push(declarationData);
+            }
+        } else {
+            // Add new declaration to the array
+            req.session.data['declarations'].push(declarationData);
+        }
+        
+        // Redirect to declaration summary
+        res.redirect('declaration-summary');
+    });
+
+    // GET handler for declaration form (for viewing existing declarations)
+    router.get('/' + version + '/declaration-form', function (req, res) {
+        const declarationIndex = req.query.index;
+        const trustName = req.query.trust;
+        let existingDeclaration = null;
+        
+        // If we have an index, find the declaration by index (for editing existing)
+        if (declarationIndex !== undefined && req.session.data['declarations'] && req.session.data['declarations'][declarationIndex]) {
+            existingDeclaration = req.session.data['declarations'][declarationIndex];
+        }
+        // If we have a trust name, find the declaration by trust name (for editing existing)
+        else if (trustName && req.session.data['declarations']) {
+            existingDeclaration = req.session.data['declarations'].find(declaration => 
+                declaration.trust.name === trustName
+            );
+        }
+        
+        // Store the trust name in session for the form submission
+        if (trustName) {
+            req.session.data.selectedDeclarationTrust = {
+                name: trustName,
+                ref: '',
+                companies: ''
+            };
+        }
+        
+        res.render(version + '/declaration-form', {
+            data: req.session.data,
+            existingDeclaration: existingDeclaration,
+            declarationIndex: declarationIndex,
+            trustName: trustName
+        });
+    });
+
+    // GET handler for declaration summary
+    router.get('/' + version + '/declaration-summary', function (req, res) {
+        // Initialize application data if not exists
+        if (!req.session.data.application) {
+            req.session.data.application = {
+                reference: req.session.data['application-reference'],
+                contributors: []
+            };
+        }
+
+        const ref = req.session.data.application.reference;
+        const application = data.applications.find(app => app.reference === ref);
+        
+        // Load contributors from application data if not already in session
+        if (application && application.contributors && (!req.session.data['contributors'] || req.session.data['contributors'].length === 0)) {
+            req.session.data['contributors'] = application.contributors;
+        }
+        
+        // Process task owners
+        let taskOwnerDisplay = 'Task owner: not assigned';
+        if (req.session.data.taskOwners?.declaration) {
+            const owners = Array.isArray(req.session.data.taskOwners.declaration) 
+                ? req.session.data.taskOwners.declaration 
+                : [req.session.data.taskOwners.declaration];
+            
+            if (owners.length > 0 && !owners.includes('_unchecked')) {
+                taskOwnerDisplay = 'Assigned to: ' + owners.map(owner => {
+                    const contributor = req.session.data['contributors'].find(c => c.email === owner);
+                    return contributor ? contributor.name : owner;
+                }).join(', ');
+            }
+        }
+        
+        // Create unique list of outgoing trusts from academies
+        let uniqueOutgoingTrusts = [];
+        if (req.session.data['academies-to-transfer'] && req.session.data['academies-to-transfer'].length > 0) {
+            const trustNames = req.session.data['academies-to-transfer'].map(academy => academy.academyTrust);
+            uniqueOutgoingTrusts = [...new Set(trustNames)];
+        }
+        
+        // Process incoming trust status
+        let incomingTrustStatus = 'Not signed yet';
+        if (req.session.data['declarations'] && req.session.data.selectedTrust) {
+            const incomingDeclaration = req.session.data['declarations'].find(declaration => 
+                declaration.trust.name === req.session.data.selectedTrust.name
+            );
+            if (incomingDeclaration) {
+                incomingTrustStatus = incomingDeclaration.status || 'Signed';
+            }
+        }
+        
+        // Process outgoing trusts status
+        let outgoingTrustsStatus = {};
+        if (uniqueOutgoingTrusts.length > 0) {
+            uniqueOutgoingTrusts.forEach(trustName => {
+                const declaration = req.session.data['declarations'] ? req.session.data['declarations'].find(declaration => 
+                    declaration.trust.name === trustName
+                ) : null;
+                outgoingTrustsStatus[trustName] = declaration ? (declaration.status || 'Signed') : 'Not signed yet';
+            });
+        }
+        
+        console.log('Debug - uniqueOutgoingTrusts:', uniqueOutgoingTrusts);
+        console.log('Debug - outgoingTrustsStatus:', outgoingTrustsStatus);
+        console.log('Debug - declarations:', req.session.data['declarations']);
+        
+        res.render(version + '/declaration-summary', {
+            data: req.session.data,
+            taskOwnerDisplay: taskOwnerDisplay,
+            uniqueOutgoingTrusts: uniqueOutgoingTrusts,
+            incomingTrustStatus: incomingTrustStatus,
+            outgoingTrustsStatus: outgoingTrustsStatus
+        });
+    });
+
+    // Handle declaration deletion
+    router.post('/' + version + '/delete-declaration-handler', function (req, res) {
+        const declarationIndex = req.body['declaration-index'];
+        const confirmDelete = req.body['confirm-delete'];
+        
+        if (confirmDelete === 'yes' && declarationIndex !== undefined && req.session.data['declarations'] && req.session.data['declarations'][declarationIndex]) {
+            // Remove the declaration at the specified index
+            req.session.data['declarations'].splice(declarationIndex, 1);
+        }
+        
+        // Redirect to declaration summary
+        res.redirect('declaration-summary');
+    });
+
+    // GET handler for confirm delete declaration page
+    router.get('/' + version + '/confirm-delete-declaration', function (req, res) {
+        req.session.data['index'] = req.query.index;
+        res.render(version + '/confirm-delete-declaration');
+    });
+
+    // Members routes
+    // GET handler for members summary
+    router.get('/' + version + '/members-summary', function (req, res) {
+        res.render(version + '/members-summary');
+    });
+
+    // GET handler for member-add - clear previous member data
+    router.get('/' + version + '/member-add', function (req, res) {
+        // Clear all member-related session data to prevent showing previous member's information
+        delete req.session.data['member-full-name'];
+        delete req.session.data['member-current-responsibilities'];
+        delete req.session.data['member-future-role'];
+        delete req.session.data['member-confirmed'];
+        res.render(version + '/member-add');
+    });
+
+    // Handle members summary form submission
+    router.post('/' + version + '/members-summary', function (req, res) {
+        // Handle completion status
+        if (req.body['members-status'] !== undefined) {
+            req.session.data['members-status'] = req.body['members-status'] === 'Complete';
+        }
+
+        // Handle member deletion
+        if (req.body['delete-member'] !== undefined) {
+            const memberIndex = parseInt(req.body['delete-member']);
+            if (req.session.data['members-to-add'] && req.session.data['members-to-add'][memberIndex]) {
+                req.session.data['members-to-add'].splice(memberIndex, 1);
+            }
+        }
+
+        // Handle member to remove deletion
+        if (req.body['delete-member-to-remove'] !== undefined) {
+            const memberIndex = parseInt(req.body['delete-member-to-remove']);
+            if (req.session.data['members-to-remove'] && req.session.data['members-to-remove'][memberIndex]) {
+                req.session.data['members-to-remove'].splice(memberIndex, 1);
+            }
+        }
+
+        // Handle member to remove add form submission
+        if (req.body['member-to-remove-full-name'] !== undefined) {
+            const fullName = req.body['member-to-remove-full-name'];
+
+            // Initialize members-to-remove array if it doesn't exist
+            if (!req.session.data['members-to-remove']) {
+                req.session.data['members-to-remove'] = [];
+            }
+
+            // Add the member to the array
+            req.session.data['members-to-remove'].push({
+                name: fullName
+            });
+        }
+
+        // Handle member future role and save complete member data
+        if (req.body['member-future-role'] !== undefined) {
+            const futureRole = req.body['member-future-role'];
+            const fullName = req.session.data['member-full-name'];
+
+            // Find the member in the array and update their data
+            if (req.session.data['members-to-add']) {
+                const memberIndex = req.session.data['members-to-add'].findIndex(m => m.name === fullName);
+                if (memberIndex !== -1) {
+                    req.session.data['members-to-add'][memberIndex].currentResponsibilities = req.session.data['member-current-responsibilities'];
+                    req.session.data['members-to-add'][memberIndex].futureRole = futureRole;
+                }
+            }
+
+            // Clear temporary session data
+            delete req.session.data['member-full-name'];
+            delete req.session.data['member-current-responsibilities'];
+            delete req.session.data['member-future-role'];
+        }
+
+        // Redirect based on the action
+        if (req.body['members-status'] !== undefined) {
+            res.redirect('application-task-list');
+        } else {
+            res.redirect('members-summary');
+        }
+    });
+
+    // Handle member add form
+    router.post('/' + version + '/member-confirmation', function (req, res) {
+        const fullName = req.body['member-full-name'];
+
+        res.render(version + '/member-confirmation', {
+            'member-full-name': fullName,
+            'member-name': fullName
+        });
+    });
+
+    // Handle member confirmation and save member
+    router.post('/' + version + '/member-current-responsibilities', function (req, res) {
+        const confirmed = req.body['member-confirmed'];
+        
+        if (confirmed === 'Yes') {
+            const fullName = req.session.data['member-full-name'];
+
+            // Initialize members-to-add array if it doesn't exist
+            if (!req.session.data['members-to-add']) {
+                req.session.data['members-to-add'] = [];
+            }
+
+            // Add the member to the array with confirmation status
+            req.session.data['members-to-add'].push({
+                name: fullName,
+                isExistingMember: true
+            });
+            
+            res.render(version + '/member-current-responsibilities');
+        } else if (confirmed === 'No') {
+            // If user selects "No", still continue to current responsibilities
+            // This means they're adding a new member, not an existing one
+            const fullName = req.session.data['member-full-name'];
+
+            // Initialize members-to-add array if it doesn't exist
+            if (!req.session.data['members-to-add']) {
+                req.session.data['members-to-add'] = [];
+            }
+
+            // Add the member to the array with confirmation status
+            req.session.data['members-to-add'].push({
+                name: fullName,
+                isExistingMember: false
+            });
+            
+            res.render(version + '/member-current-responsibilities');
+        } else {
+            // Default fallback
+            res.redirect('members-summary');
+        }
+    });
+
+    // Handle member future role
+    router.post('/' + version + '/member-future-role', function (req, res) {
+        const currentResponsibilities = req.body['member-current-responsibilities'];
+        
+        // Save to session for the current member being added
+        req.session.data['member-current-responsibilities'] = currentResponsibilities;
+
+        res.render(version + '/member-future-role');
+    });
+
+    // Handle member deletion confirmation
+    router.get('/' + version + '/confirm-delete-member', function (req, res) {
+        const memberIndex = parseInt(req.query.index);
+        req.session.data['delete-member-index'] = memberIndex;
+
+        res.render(version + '/confirm-delete-member', {
+            index: memberIndex
+        });
+    });
+
+    // Handle member to remove deletion confirmation
+    router.get('/' + version + '/confirm-delete-member-to-remove', function (req, res) {
+        const memberIndex = parseInt(req.query.index);
+        req.session.data['delete-member-to-remove-index'] = memberIndex;
+
+        res.render(version + '/confirm-delete-member-to-remove', {
+            index: memberIndex
+        });
+    });
+
+}

--- a/app/views/alpha-sprint-18/academies-to-transfer-confirmation.html
+++ b/app/views/alpha-sprint-18/academies-to-transfer-confirmation.html
@@ -1,0 +1,63 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Confirm academy" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form class="form" action="add-more-academies-handler" method="post">
+      {% set selectedAcademy = data['selected-academy'].split('|||') %}
+      {% set academyName = selectedAcademy[0] %}
+      {% set academyUrn = selectedAcademy[1] %}
+      {% set academyPostcode = selectedAcademy[2] %}
+      {% set academyTrust = selectedAcademy[3] %}
+
+      {{ govukRadios({
+        idPrefix: "confirm-academy",
+        name: "confirm-academy",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Details of academies</span>
+            Is this the right academy?',
+            classes: "govuk-fieldset__legend--xl",
+            isPageHeading: true
+          }
+        },
+        hint: {
+          html: '<div class="govuk-inset-text">
+            <h2 class="govuk-heading-m">' + academyName + '</h2>
+            <p class="govuk-body">URN: ' + academyUrn + '</p>
+            <p class="govuk-body">Postcode: ' + academyPostcode + '</p>
+            <p class="govuk-body">Trust: ' + academyTrust + '</p>
+          </div>'
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            value: "no",
+            text: "No"
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/academies-to-transfer-search-results.html
+++ b/app/views/alpha-sprint-18/academies-to-transfer-search-results.html
@@ -1,0 +1,46 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Academy search results" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form class="form" action="academies-to-transfer-confirmation" method="post">
+      <!-- Debug output -->
+      <pre>{{ data.academies | dump }}</pre>
+
+      {{ govukRadios({
+        idPrefix: "selected-academy",
+        name: "selected-academy",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Details of academies</span>
+            Select an academy',
+            classes: "govuk-fieldset__legend--xl",
+            isPageHeading: true
+          }
+        },
+        hint: {
+          text: "The following academies match your search"
+        },
+        items: radioItems
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/academies-to-transfer-search.html
+++ b/app/views/alpha-sprint-18/academies-to-transfer-search.html
@@ -1,0 +1,44 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Search for an academy" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form class="form" action="academies-to-transfer-search-results" method="post">
+        <input hidden type="text" name="returnToSummary" value="no"/>
+
+        {{ govukInput({
+          label: {
+            html: '<span class="govuk-caption-l">Details of academies</span>
+            Search for an academy by name or reference number',
+            classes: "govuk-label--xl",
+            isPageHeading: true
+          },
+          hint: {
+            text: "For example, search by unique reference number (URN)"
+          },
+          id: "create-new-project-academy-name",
+          name: "create-new-project-academy-name",
+          value: data["create-new-project-academy-name"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/alpha-sprint-18/academies-to-transfer-summary.html
+++ b/app/views/alpha-sprint-18/academies-to-transfer-summary.html
@@ -1,0 +1,109 @@
+{% extends "layouts/main.html" %}
+
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% set pageName="Details of academies" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "application-task-list?ref=" + data.application.reference,
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    {% if success %}
+      {% set html %}
+        <h3 class="govuk-notification-banner__heading">
+          {{ removedAcademy }} has been removed
+        </h3>
+      {% endset %}
+
+      {{ govukNotificationBanner({
+        type: "success",
+        html: html
+      }) }}
+    {% endif %}
+
+    {% if error %}
+      <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div role="alert">
+          <h2 class="govuk-error-summary__title">
+            There is a problem
+          </h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              <li>
+                <a href="#academies-to-transfer">You must select at least one academy before confirming</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="academies-to-transfer">
+      Details of academies
+    </h1>
+
+    <p class="govuk-body eat-transfer__task-owner-box">
+      {{ taskOwnerDisplay }} <a class="govuk-link" href="task-owner-update?task=academies">Change</a>
+    </p>
+
+    {% if not data['academies-to-transfer'] or data['academies-to-transfer'].length === 0 %}
+      <div class="govuk-inset-text">
+        No academies have been added.
+      </div>
+    {% else %}
+      <dl class="govuk-summary-list">
+        {% for academy in data['academies-to-transfer'] %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Academy {{ loop.index }}
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <p class="govuk-body">{{ academy.name }}</p>
+              <p class="govuk-body govuk-!-margin-bottom-0">URN: {{ academy.urn }}</p>
+              <p class="govuk-body govuk-!-margin-bottom-0">Postcode: {{ academy.postcode }}</p>
+              <p class="govuk-body govuk-!-margin-bottom-0">Trust: {{ academy.academyTrust }}</p>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="confirm-delete-academy?index={{ loop.index0 }}">
+                Remove<span class="govuk-visually-hidden"> academy {{ loop.index }}</span>
+              </a>
+            </dd>
+          </div>
+        {% endfor %}
+      </dl>
+    {% endif %}
+
+    <a href="academies-to-transfer-search" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-9" data-module="govuk-button">
+      Add academy
+    </a>
+
+    <form action="application-task-list" method="post">
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="academies-to-transfer-status" name="academies-to-transfer-status" type="checkbox" value="Complete" {% if data['academies-to-transfer-status'] %}checked{% endif %}>
+            <label class="govuk-label govuk-checkboxes__label" for="academies-to-transfer-status">
+              Mark this section as complete, you can still make changes later
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/add-more-academies.html
+++ b/app/views/alpha-sprint-18/add-more-academies.html
@@ -1,0 +1,56 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Add academy" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form class="form" action="add-more-academies-handler" method="post">
+      {% set selectedAcademy = data['selected-academy'].split('|||') %}
+      {% set academyName = selectedAcademy[0] %}
+      {% set academyUrn = selectedAcademy[1] %}
+
+      {{ govukRadios({
+        idPrefix: "confirm-academy",
+        name: "confirm-academy",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Stage 1 - academies to transfer</span>
+            Add ' + academyName + ' to your application',
+            classes: "govuk-fieldset__legend--xl",
+            isPageHeading: true
+          }
+        },
+        hint: {
+          text: "This academy will be added to your application"
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes, add this academy"
+          },
+          {
+            value: "no",
+            text: "No, do not add this academy"
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/application-complete.html
+++ b/app/views/alpha-sprint-18/application-complete.html
@@ -1,0 +1,51 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName = "Application complete" %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    {{ govukPanel({
+      titleText: "Application submitted",
+      html: "Your reference number<br><strong>" + refNumber + "</strong>"
+    }) }}
+
+    <h2 class="govuk-heading-m">What happens next</h2>
+
+    <p class="govuk-body">
+      We've sent you a confirmation email with your reference number.
+    </p>
+    <p class="govuk-body">
+      A Department for Education staff member will get in touch with you about your application.
+    </p>
+
+    <p class="govuk-body">
+      A Regional Director will make a decision on your application within 3 months.
+    </p>
+    <p class="govuk-body">
+      <a href="dashboard" class="govuk-link">Track your application</a>.
+    </p>
+
+    <h2 class="govuk-heading-m">Contact us</h2>
+    
+    <p class="govuk-body">
+      If you have any questions about your application, you can contact the Department for Education staff member who will get in touch with you. 
+    </p>
+
+    <p class="govuk-body">
+      You can also contact the academies team:
+    </p>
+
+    <ul class="govuk-list">
+      <li>Email: <a class="govuk-link" href="mailto:academies.enquiry@education.gov.uk">academies.enquiry@education.gov.uk</a></li>
+      <li>Telephone: 0800 000 000</li>
+      <li>Monday to Friday, 9am to 5pm (except public holidays)</li>
+    </ul>
+
+  </div>
+</div>
+{% endblock %} 

--- a/app/views/alpha-sprint-18/application-task-list.html
+++ b/app/views/alpha-sprint-18/application-task-list.html
@@ -1,0 +1,405 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Your application" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <a href="dashboard" class="govuk-back-link govuk-!-margin-bottom-9">Back to dashboard</a>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+      Your application 
+    </h1>
+  </div>
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <div class="govuk-inset-text govuk-!-margin-bottom-9">
+      <p>
+        Application reference: <strong>{{ data.application.reference }}</strong>
+      </p>
+      <p>
+        Lead applicant: <strong>{{ data.application.leadApplicant }}</strong>
+      </p>
+    </div>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">About transferring academies</h2>
+    <ul class="govuk-task-list">
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="academies-to-transfer-summary" aria-describedby="academies-to-transfer-status">
+            Details of academies
+          </a>
+          <div id="task-1-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('academies-to-transfer') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="details-of-academies-  status">
+          {% if data['academies-to-transfer-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="reason-and-benefits-academies" aria-describedby="reason-and-benefits-academies-status">
+            Reason and benefits
+          </a>
+          <div id="task-2-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('reason-and-benefits-academies-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="reason-and-benefits-academies-status">
+          {% if data['reason-and-benefits-academies-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="risks-summary" aria-describedby="risks-status">
+            Risks
+          </a>
+          <div id="task-3-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('risks-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="risks-status">
+          {% if data['risks-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">About the incoming trust</h2>
+    <ul class="govuk-task-list">
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="incoming-trust-summary" aria-describedby="incoming-trust-status">
+            Trust details
+          </a>
+          <div id="task-2-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('incoming-trust') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="incoming-trust-status">
+          {% if data['incoming-trust-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="reason-and-benefits-trust" aria-describedby="reason-and-benefits-trust-status">
+            Reason and benefits
+          </a>
+          <div id="task-2-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('reason-and-benefits-trust-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="reason-and-benefits-trust-status">
+          {% if data['reason-and-benefits-trust-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="high-quality-and-inclusive-education" aria-describedby="high-quality-and-inclusive-education-status">
+            High-quality and inclusive education
+          </a>
+          <div id="task-4-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('high-quality-and-inclusive-education-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="high-quality-and-inclusive-education-status">
+          {% if data['high-quality-and-inclusive-education-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="school-improvement" aria-describedby="school-improvement-status">
+            School improvement 
+          </a>
+          <div id="task-5-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('school-improvement-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="school-improvement-status">
+          {% if data['school-improvement-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="#" aria-describedby="finance-and-operations-status">
+            Finance and operations
+          </a>
+          <div id="task-5-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('finance-and-operations-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="finance-and-operations-status">
+          {% if data['finance-and-operations-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="#" aria-describedby="leadership-and-work-force-status">
+            Leadership and work force 
+          </a>
+          <div id="task-6-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('leadership-and-work-force-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="leadership-and-work-force-status">
+          {% if data['leadership-and-work-force-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="members-summary" aria-describedby="members-status">
+            Members
+          </a>
+          <div id="task-7-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('members-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="members-status">
+          {% if data['members-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="governance-structure" aria-describedby="governance-status">
+            Governance structure
+          </a>
+          <div id="task-6-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('governance-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="governance-status">
+          {% if data['governance-structure-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+    </ul>
+
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">Consent and consultations</h2>
+    <ul class="govuk-task-list">
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="#" aria-describedby="diocesan-consent-status">
+            Diocesan consent 
+          </a>
+          <div id="task-6-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('diocesan-consent-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="diocesan-consent-status">
+          {% if data['diocesan-consent-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="#" aria-describedby="board-resolutions-status">
+            Board resolutions
+          </a>
+          <div id="task-6-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('board-resolutions-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="board-resolutions-status">
+          {% if data['board-resolutions-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="#" aria-describedby="results-of-consultations-and-other-stakeholder-engagements-status">
+            Results of consultations and other stakeholder engagements
+          </a>
+          <div id="task-6-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('results-of-consultations-and-other-stakeholder-engagements-status') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="results-of-consultations-and-other-stakeholder-engagements-status">
+          {% if data['results-of-consultations-and-other-stakeholder-engagements-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+    </ul>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-9">Declaration</h2>
+
+    <ul class="govuk-task-list">
+      <li class="govuk-task-list__item govuk-task-list__item--with-link">
+        <div class="govuk-task-list__name-and-hint">
+          <a class="govuk-link govuk-task-list__link" href="declaration-summary" aria-describedby="declaration-status">
+            Declaration from academy trust chair
+          </a>
+          <div id="task-declaration-hint" class="govuk-task-list__hint">
+            <span class="hint-name">
+              <strong>{{ processTaskOwners('declaration') }}</strong>
+            </span>
+          </div>
+        </div>
+        <div class="govuk-task-list__status" id="declaration-status">
+          {% if data['declaration-status'] %}
+            <strong class="govuk-tag govuk-tag--green">
+              Completed
+            </strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--blue">
+              Incomplete
+            </strong>
+          {% endif %}
+        </div>
+      </li>
+    </ul>
+
+    <div class="govuk-button-group govuk-!-margin-top-9">
+      <form action="check-your-answers" method="post">
+        <button class="govuk-button" type="submit">Preview application</button>
+      </form>
+    </div>
+    
+  </div>
+  <div class="govuk-grid-column-one-third govuk-!-margin-bottom-6">
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Inviting contributors</h2>
+
+    <p class="govuk-body">
+      You can invite other people to complete parts of this application.
+    </p>
+    <a href="contributors-home" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">Invite contributors</a>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/alpha-sprint-18/check-your-answers.html
+++ b/app/views/alpha-sprint-18/check-your-answers.html
@@ -1,0 +1,645 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Your application" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Your application</h1>
+    
+    <div class="govuk-inset-text govuk-!-margin-bottom-9">
+      <p>
+        Application reference: <strong>{{ data.application.reference if data.application else 'Not set' }}</strong>
+      </p>
+      <p>
+        Lead applicant: <strong>{{ data.application.leadApplicant if data.application else 'Not set' }}</strong>
+      </p>
+    </div>
+
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">Details of academies</h2>
+        {% if data.application and data.application.status !== 'Submitted' %}
+          <div class="govuk-summary-card__actions">
+            <a class="govuk-link" href="academies-to-transfer">
+              Change<span class="govuk-visually-hidden"> details of academies</span>
+            </a>
+          </div>
+        {% endif %}
+      </div>
+      <div class="govuk-summary-card__content">
+        {% if not data['academies-to-transfer'] or data['academies-to-transfer'].length === 0 %}
+          <div class="govuk-inset-text">
+            No academies have been selected.
+          </div>
+        {% else %}
+          <dl class="govuk-summary-list">
+            {% for academy in data['academies-to-transfer'] %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Academy {{ loop.index }}
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  <p class="govuk-body">{{ academy.name }}</p>
+                  <p class="govuk-body govuk-!-margin-bottom-0">URN: {{ academy.urn }}</p>
+                </dd>
+              </div>
+            {% endfor %}
+          </dl>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">Reason and benefits (Academies)</h2>
+        {% if data.application and data.application.status !== 'Submitted' %}
+          <div class="govuk-summary-card__actions">
+            <a class="govuk-link" href="reason-and-benefits-academies">
+              Change<span class="govuk-visually-hidden"> reason and benefits (academies)</span>
+            </a>
+          </div>
+        {% endif %}
+      </div>
+      <div class="govuk-summary-card__content">
+        {% if not data['reason-and-benefits-academies-strategic-needs'] and not data['reason-and-benefits-academies-maintain-improve'] and not data['reason-and-benefits-academies-benefit-trust'] %}
+          <div class="govuk-inset-text">
+            No reason and benefits information has been added.
+          </div>
+        {% else %}
+          <dl class="govuk-summary-list">
+            {% if data['reason-and-benefits-academies-strategic-needs'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                What are the strategic needs of the transferring academies and their local areas?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['reason-and-benefits-academies-strategic-needs'] }}
+              </dd>
+            </div>
+            {% endif %}
+
+            {% if data['reason-and-benefits-academies-maintain-improve'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                How will the transferring academies help maintain and improve existing academies in the trust?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['reason-and-benefits-academies-maintain-improve'] }}
+              </dd>
+            </div>
+            {% endif %}
+
+            {% if data['reason-and-benefits-academies-benefit-trust'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                How will the transferring academies benefit the trust?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['reason-and-benefits-academies-benefit-trust'] }}
+              </dd>
+            </div>
+            {% endif %}
+          </dl>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">Risks</h2>
+        {% if data.application and data.application.status !== 'Submitted' %}
+          <div class="govuk-summary-card__actions">
+            <a class="govuk-link" href="risks-summary">
+              Change<span class="govuk-visually-hidden"> risks</span>
+            </a>
+          </div>
+        {% endif %}
+      </div>
+      <div class="govuk-summary-card__content">
+        {% if not data['risks-due-diligence'] and not data['risks-pupil-numbers'] %}
+          <div class="govuk-inset-text">
+            No risks information has been added.
+          </div>
+        {% else %}
+          <dl class="govuk-summary-list">
+            {% if data['risks-due-diligence'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                What due diligence activities have been carried out on the transferring academies?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['risks-due-diligence'] }}
+              </dd>
+            </div>
+            {% endif %}
+            {% if data['risks-pupil-numbers'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Are pupil numbers in any transferring academy expected to drop below 85% of the school capacity?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['risks-pupil-numbers'] }}
+              </dd>
+            </div>
+            {% endif %}
+            {% if data['risks-pupil-numbers'] === 'Yes' and data['risks-pupil-forecast'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Provide a 3 year forecast of pupil numbers and plans to improve this
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['risks-pupil-forecast'] }}
+              </dd>
+            </div>
+            {% endif %}
+            {% if data['risks-financial-deficit'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Do any transferring academy have an in-year deficit or overall deficit?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['risks-financial-deficit'] }}
+              </dd>
+            </div>
+            {% endif %}
+            {% if data['risks-financial-deficit'] === 'Yes' and data['risks-financial-forecast'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Provide a 3 year financial forecast for the academy and your plans to bring the academy into surplus
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['risks-financial-forecast'] }}
+              </dd>
+            </div>
+            {% endif %}
+            {% if data['risks-finances-pooled'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Are any transferring academy's finances currently pooled?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['risks-finances-pooled'] }}
+              </dd>
+            </div>
+            {% endif %}
+            {% if data['risks-finances-pooled'] === 'Yes' and data['risks-reserves-transfer'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                How much of the reserves and funding allocated to the academies will transfer over?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['risks-reserves-transfer'] }}
+              </dd>
+            </div>
+            {% endif %}
+            {% if data['risks-other-risks'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Are there other risks related to the transferring academies?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['risks-other-risks'] }}
+              </dd>
+            </div>
+            {% endif %}
+            {% if data['risks-other-risks'] === 'Yes' and data['risks-risk-management'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                What are the risks and the plans to manage them?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['risks-risk-management'] }}
+              </dd>
+            </div>
+            {% endif %}
+          </dl>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">Trust details</h2>
+        {% if data.application and data.application.status !== 'Submitted' %}
+          <div class="govuk-summary-card__actions">
+            <a class="govuk-link" href="incoming-trust-summary">
+              Change<span class="govuk-visually-hidden"> trust details</span>
+            </a>
+          </div>
+        {% endif %}
+      </div>
+      <div class="govuk-summary-card__content">
+        {% if not data['new-trust'] %}
+          <div class="govuk-inset-text">
+            No incoming trust information has been added.
+          </div>
+        {% else %}
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Is the result of this transfer the formation of a new trust?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ "Yes" if data['new-trust'] === 'yes' else "No" }}
+              </dd>
+            </div>
+
+            {% if data['new-trust'] === 'yes' %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                New trust
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['proposed-trust-name'] }}
+              </dd>
+            </div>
+            {% else %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Is there a preferred trust for these academies?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ "Yes" if data['preferred-trust'] === 'yes' else "No" }}
+              </dd>
+            </div>
+
+            {% if data['preferred-trust'] === 'yes' and data['selected-trust'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Preferred trust
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">{{ data.selectedTrust.name }}</p>
+                <p class="govuk-body">TRN: {{ data.selectedTrust.ref }}</p>
+                <p class="govuk-body govuk-!-margin-bottom-0">UKPRN: {{ data.selectedTrust.companies }}</p>
+              </dd>
+            </div>
+            {% endif %}
+            {% endif %}
+          </dl>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">Reason and benefits (Trust)</h2>
+        {% if data.application and data.application.status !== 'Submitted' %}
+          <div class="govuk-summary-card__actions">
+            <a class="govuk-link" href="reason-and-benefits-trust">
+              Change<span class="govuk-visually-hidden"> reason and benefits (trust)</span>
+            </a>
+          </div>
+        {% endif %}
+      </div>
+      <div class="govuk-summary-card__content">
+        {% if not data['reason-and-benefits-trust-strategic-needs'] and not data['reason-and-benefits-trust-maintain-improve'] %}
+          <div class="govuk-inset-text">
+            No reason and benefits information has been added.
+          </div>
+        {% else %}
+          <dl class="govuk-summary-list">
+            {% if data['reason-and-benefits-trust-strategic-needs'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                What are the strategic needs of the trust?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['reason-and-benefits-trust-strategic-needs'] }}
+              </dd>
+            </div>
+            {% endif %}
+
+            {% if data['reason-and-benefits-trust-maintain-improve'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                How will the trust support the developmental needs of the transferring academies?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['reason-and-benefits-trust-maintain-improve'] }}
+              </dd>
+            </div>
+            {% endif %}
+
+            <!-- Temporarily hidden: What type of transfer it is?
+            {% if data['reason-and-benefits-trust-transfer-type'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                What type of transfer it is?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['reason-and-benefits-trust-transfer-type'] }}
+              </dd>
+            </div>
+            {% endif %}
+            -->
+          </dl>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">High-quality and inclusive education</h2>
+        {% if data.application and data.application.status !== 'Submitted' %}
+          <div class="govuk-summary-card__actions">
+            <a class="govuk-link" href="high-quality-and-inclusive-education">
+              Change<span class="govuk-visually-hidden"> high-quality and inclusive education</span>
+            </a>
+          </div>
+        {% endif %}
+      </div>
+      <div class="govuk-summary-card__content">
+        {% if not data['high-quality-and-inclusive-education-quality'] and not data['high-quality-and-inclusive-education-inclusive'] %}
+          <div class="govuk-inset-text">
+            No high-quality and inclusive education information has been added.
+          </div>
+        {% else %}
+          <dl class="govuk-summary-list">
+            {% if data['high-quality-and-inclusive-education-quality'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                How do the existing academies at the trust provide high quality and inclusive education?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['high-quality-and-inclusive-education-quality'] }}
+              </dd>
+            </div>
+            {% endif %}
+
+            {% if data['high-quality-and-inclusive-education-inclusive'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                How will the transfer impact the trust and transferring academies?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['high-quality-and-inclusive-education-inclusive'] }}
+              </dd>
+            </div>
+            {% endif %}
+          </dl>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">School improvement</h2>
+        {% if data.application and data.application.status !== 'Submitted' %}
+          <div class="govuk-summary-card__actions">
+            <a class="govuk-link" href="school-improvement">
+              Change<span class="govuk-visually-hidden"> school improvement</span>
+            </a>
+          </div>
+        {% endif %}
+      </div>
+      <div class="govuk-summary-card__content">
+        {% if not data['school-improvement-model'] %}
+          <div class="govuk-inset-text">
+            No school improvement information has been added.
+          </div>
+        {% else %}
+          <dl class="govuk-summary-list">
+            {% if data['school-improvement-model'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                What will be the trust's school improvement model and how will it be actioned?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['school-improvement-model'] }}
+              </dd>
+            </div>
+            {% endif %}
+          </dl>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">Members</h2>
+        {% if data.application and data.application.status !== 'Submitted' %}
+          <div class="govuk-summary-card__actions">
+            <a class="govuk-link" href="members-summary">
+              Change<span class="govuk-visually-hidden"> members</span>
+            </a>
+          </div>
+        {% endif %}
+      </div>
+      
+      {% if not data['members-to-add'] and not data['members-to-remove'] %}
+        <div class="govuk-summary-card__content">
+          <div class="govuk-inset-text">
+            No members information has been added.
+          </div>
+        </div>
+      {% else %}
+        {% if data['members-to-add'] and data['members-to-add'].length > 0 %}
+          <div class="govuk-summary-card__content">
+            <h3 class="govuk-heading-s">Who will be the Members of the trust after the transfer?</h3>
+            <dl class="govuk-summary-list">
+              {% for member in data['members-to-add'] %}
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Member {{ loop.index }}
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <p class="govuk-body">{{ member.name }}</p>
+                  </dd>
+                </div>
+                {% if member.isExistingMember is defined %}
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Is {{ member.name }} an existing member or a new one?
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <p class="govuk-body">{% if member.isExistingMember %}Yes{% else %}No{% endif %}</p>
+                  </dd>
+                </div>
+                {% endif %}
+                {% if member.currentResponsibilities %}
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    What roles and responsibilities has {{ member.name }} had in the past 5 years?
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <p class="govuk-body">{{ member.currentResponsibilities }}</p>
+                  </dd>
+                </div>
+                {% endif %}
+                {% if member.futureRole %}
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Will {{ member.name }} also have any of these roles?
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    {% if member.futureRole is string %}
+                      <p class="govuk-body">{{ member.futureRole }}</p>
+                    {% else %}
+                      <ul class="govuk-list govuk-list--bullet">
+                        {% for role in member.futureRole %}
+                          {% if role and role !== '_unchecked' %}
+                            <li>{{ role }}</li>
+                          {% endif %}
+                        {% endfor %}
+                      </ul>
+                    {% endif %}
+                  </dd>
+                </div>
+                {% endif %}
+              {% endfor %}
+            </dl>
+          </div>
+        {% endif %}
+
+        {% if data['members-to-remove'] and data['members-to-remove'].length > 0 %}
+          <div class="govuk-summary-card__content">
+            <h3 class="govuk-heading-s">Current members who will be leaving</h3>
+            <dl class="govuk-summary-list">
+              {% for member in data['members-to-remove'] %}
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Person to leave {{ loop.index }}
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <p class="govuk-body">{{ member.name }}</p>
+                  </dd>
+                </div>
+              {% endfor %}
+            </dl>
+          </div>
+        {% endif %}
+      {% endif %}
+    </div>
+
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">Governance structure</h2>
+        {% if data.application and data.application.status !== 'Submitted' %}
+          <div class="govuk-summary-card__actions">
+            <a class="govuk-link" href="governance-structure">
+              Change<span class="govuk-visually-hidden"> governance structure</span>
+            </a>
+          </div>
+        {% endif %}
+      </div>
+      <div class="govuk-summary-card__content">
+        {% if not data['governance-structure-files'] or data['governance-structure-files'].length === 0 %}
+          <div class="govuk-inset-text">
+            No governance structure information has been added.
+          </div>
+        {% else %}
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Governance structure after the transfer
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {% if data['governance-structure-files'] and data['governance-structure-files'].length > 0 %}
+                  {% for file in data['governance-structure-files'] %}
+                    <p class="govuk-body">
+                      <a href="download-governance-file/{{ loop.index0 }}" class="govuk-link" target="_blank" rel="noopener noreferrer">
+                        <strong>{{ file.name }}</strong>
+                      </a>
+                    </p>
+                    <p class="govuk-body govuk-!-font-size-14">
+                      File size: {{ (file.size / 1024 / 1024).toFixed(2) }} MB
+                    </p>
+                    <p class="govuk-body govuk-!-font-size-14">
+                      File type: {{ file.type }}
+                    </p>
+                    {% if not loop.last %}
+                      <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-4 govuk-!-margin-bottom-4">
+                    {% endif %}
+                  {% endfor %}
+                {% else %}
+                  <p class="govuk-body">No files uploaded</p>
+                {% endif %}
+              </dd>
+            </div>
+          </dl>
+        {% endif %}
+
+        {% if data['governance-team-confirmed'] %}
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Has the trust confirmed everyone who will be on the governance team after the transfer?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">{{ data['governance-team-confirmed'] }}</p>
+              </dd>
+            </div>
+            {% if data['governance-team-confirmed'] === 'No' and data['governance-team-explanation'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Tell us about anyone who is considering joining the governance team
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">{{ data['governance-team-explanation'] }}</p>
+              </dd>
+            </div>
+            {% endif %}
+          </dl>
+        {% endif %}
+      </div>
+    </div>
+
+    
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">Declaration from academy trust chair</h2>
+        {% if data.application and data.application.status !== 'Submitted' %}
+          <div class="govuk-summary-card__actions">
+            <a class="govuk-link" href="declaration-summary">
+              Change<span class="govuk-visually-hidden"> declaration from academy trust chair</span>
+            </a>
+          </div>
+        {% endif %}
+      </div>
+      <div class="govuk-summary-card__content">
+        {% if not data['declarations'] or data['declarations'].length === 0 %}
+          <div class="govuk-inset-text">
+            No declarations have been added.
+          </div>
+        {% else %}
+          <dl class="govuk-summary-list">
+            {% for declaration in data['declarations'] %}
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Declaration {{ loop.index }}
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body"><strong>{{ declaration.trust.name }}</strong></p>
+                <p class="govuk-body">Chair of trustees: {{ declaration.chairOfTrustees }}</p>
+                <p class="govuk-body govuk-!-margin-bottom-0">Date: {{ declaration.dateOfDeclaration.day }}/{{ declaration.dateOfDeclaration.month }}/{{ declaration.dateOfDeclaration.year }}</p>
+              </dd>
+            </div>
+            {% endfor %}
+          </dl>
+        {% endif %}
+      </div>
+    </div>
+
+    
+    {% if data.application and data.application.status !== 'Submitted' %}
+      <h2 class="govuk-heading-m">Now submit your application</h2>
+      <p class="govuk-body">By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
+
+      <form action="application-complete" method="post">
+        <button class="govuk-button" type="submit">Submit application</button>
+      </form>
+    {% endif %}
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/cites-imports-and-exports.html
+++ b/app/views/alpha-sprint-18/cites-imports-and-exports.html
@@ -1,0 +1,186 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Check if you need a CITES permit to import or export endangered species
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      },
+      {
+        text: "Environment",
+        href: "#"
+      },
+      {
+        text: "Wildlife, animals, biodiversity and ecosystems",
+        href: "#"
+      },
+      {
+        text: "Biodiversity and ecosystems",
+        href: "#"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl" style="margin-bottom: 20px;">Check if you need a CITES permit to import or export endangered species</h1>
+
+      <p class="govuk-body-l" style="margin-bottom: 30px;">Check if your import, export or re-export needs a permit or certificate under the Convention on International Trade in Endangered Species of Wild Fauna and Flora (CITES).</p>
+
+      <p class="govuk-body" style="margin-bottom: 30px;">From: <a href="#" class="govuk-link">Animal and Plant Health Agency</a> and <a href="#" class="govuk-link">Department for Environment, Food & Rural Affairs</a></p>
+
+      <div class="govuk-metadata" style="margin-bottom: 30px; color: #505a5f; font-size: 16px;">
+        <dl style="margin: 0; padding: 0;">
+          <dt style="display: inline; margin-right: 5px;">Published:</dt>
+          <dd style="display: inline; margin: 0;">1 January 2013</dd>
+          <dt style="display: inline; margin-left: 20px; margin-right: 5px;">Last updated:</dt>
+          <dd style="display: inline; margin: 0;">14 March 2025</dd>
+        </dl>
+      </div>
+
+      <div class="govuk-inset-text" style="margin-bottom: 30px; border-left-color: #1d70b8;">
+        <p class="govuk-body" style="margin-bottom: 15px;">You must apply for a permit if you're moving a specimen of any CITES listed species either into or out of Great Britain (England, Scotland and Wales). This includes moving a specimen to or from:</p>
+        <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 0;">
+          <li>the EU</li>
+          <li>non-EU countries</li>
+          <li>Northern Ireland</li>
+          <li>Jersey, Guernsey or the Isle of Man</li>
+        </ul>
+      </div>
+
+      <h2 class="govuk-heading-m" style="margin-bottom: 20px;">Contents</h2>
+      <ul class="govuk-list govuk-list--dash" style="margin-bottom: 30px;">
+        <li><a href="#how-to-apply" class="govuk-link">How to apply</a></li>
+        <li><a href="#other-permits" class="govuk-link">Other permits and certificates</a></li>
+        <li><a href="#before-permit" class="govuk-link">Before you receive your permit</a></li>
+        <li><a href="#how-long" class="govuk-link">How long it takes</a></li>
+        <li><a href="#after-permit" class="govuk-link">After you receive your permit</a></li>
+        <li><a href="#import-export" class="govuk-link">Importing or exporting your species</a></li>
+        <li><a href="#returned-goods" class="govuk-link">Returned goods</a></li>
+        <li><a href="#marking" class="govuk-link">Marking specimens</a></li>
+        <li><a href="#help" class="govuk-link">Get help</a></li>
+      </ul>
+
+      <h2 id="how-to-apply" class="govuk-heading-m" style="margin-bottom: 20px;">How to apply</h2>
+      <p class="govuk-body" style="margin-bottom: 15px;">You should:</p>
+      <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 30px;">
+        <li>use Species+ to check if your specimen comes from a species on the CITES list</li>
+        <li>apply for an import, export or re-export permit using the apply for a CITES permit service – this new digital service replaces CITES forms</li>
+      </ul>
+      <p class="govuk-body" style="margin-bottom: 15px;">As part of your application, find the trade term code.</p>
+      <p class="govuk-body" style="margin-bottom: 15px;">You must get a permit for any species listed on annex A, B or C in Species+.</p>
+      <p class="govuk-body" style="margin-bottom: 30px;">You can only import specimens of annex A species in exceptional circumstances. This is to avoid endangering the species further. Contact the APHA team for endangered plant and animal species for more detailed advice if you want to import a specimen of an annex A species.</p>
+
+      <h2 id="other-permits" class="govuk-heading-m" style="margin-bottom: 20px;">Other permits and certificates</h2>
+      <p class="govuk-body" style="margin-bottom: 15px;">You can apply to import annex C specimens. To do this you'll need to get an import notification form by emailing APHA at wildlife.licensing@apha.gov.uk or phoning 03000 200 301.</p>
+
+      <h3 class="govuk-heading-s" style="margin-bottom: 15px;">Commercial use</h3>
+      <p class="govuk-body" style="margin-bottom: 15px;">If you plan to use any specimen listed by CITES in annex A for commercial purposes, you must get a commercial use certificate (known as an Article 10 certificate).</p>
+      <p class="govuk-body" style="margin-bottom: 30px;">If you're importing an annex A specimen to sell it, you may be able to get a permit that can be used instead of an Article 10 certificate. Please contact APHA for more information by emailing wildlife.licensing@apha.gov.uk.</p>
+
+      <h3 class="govuk-heading-s" style="margin-bottom: 15px;">Musical instruments, museums, art exhibitions and touring displays</h3>
+      <p class="govuk-body" style="margin-bottom: 15px;">In some cases, you may need to move CITES specimens across international borders several times. For example, endangered species or specimens that are part of a:</p>
+      <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 15px;">
+        <li>touring orchestra</li>
+        <li>museum exhibit</li>
+        <li>art exhibition</li>
+        <li>touring display or circus</li>
+      </ul>
+      <p class="govuk-body" style="margin-bottom: 30px;">If you're travelling with your instrument as part of a touring orchestra, you must use the apply for a CITES permit service for each instrument containing CITES listed specimens. You do not have to pay for a musical instrument certificate.</p>
+
+      <h3 class="govuk-heading-s" style="margin-bottom: 15px;">Ivory</h3>
+      <p class="govuk-body" style="margin-bottom: 30px;">Read the guide on dealing in items containing ivory or made of ivory if you intend to trade or move ivory (teeth or tusks, and items made from them) from any of the following species:</p>
+      <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 30px;">
+        <li>elephant</li>
+        <li>common hippopotamus</li>
+        <li>killer whale</li>
+        <li>narwhal</li>
+        <li>sperm whale</li>
+      </ul>
+
+      <h3 class="govuk-heading-s" style="margin-bottom: 15px;">Personal and household effects</h3>
+      <p class="govuk-body" style="margin-bottom: 15px;">In some specific circumstances, you do not need CITES documentation to move personal and household items that contain a CITES specimen.</p>
+      <p class="govuk-body" style="margin-bottom: 15px;">You do not need a CITES permit for the following items if they are carried in your personal luggage and intended for personal use (allowance is per person):</p>
+      <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 30px;">
+        <li>125 grams of caviar (Acipenseriformes spp), in containers that are individually marked in accordance with Article 66(6)</li>
+        <li>3 rainsticks of Cactaceae spp</li>
+        <li>4 worked items containing Crocodyllia spp (excluding meat and hunting trophies)</li>
+        <li>3 shells of Queen conch (Strombus gigas)</li>
+        <li>4 dead specimens of seahorse (Hippocampus spp)</li>
+        <li>3 specimens of giant clam (Tridacnidae spp) not more than 3kg in total, where a specimen can be one intact shell or 2 matching halves</li>
+        <li>up to 1kg woodchips, 24ml oil, and 2 sets of beads or prayer beads (or 2 necklaces or bracelets) of agarwood (Aquilaria and Gyrinops species)</li>
+      </ul>
+
+      <h2 id="before-permit" class="govuk-heading-m" style="margin-bottom: 20px;">Before you receive your permit</h2>
+      <p class="govuk-body" style="margin-bottom: 15px;">Until you have the correct CITES permit, you should not:</p>
+      <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 15px;">
+        <li>ship or travel with specimens</li>
+        <li>make any payments for specimens</li>
+        <li>enter into contracts over specimens</li>
+      </ul>
+      <p class="govuk-body" style="margin-bottom: 15px;">You must check:</p>
+      <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 30px;">
+        <li>the requirements of the import or export country by contacting the CITES authority in that country</li>
+        <li>if your specimen is subject to an import suspension (negative opinion)</li>
+      </ul>
+
+      <h2 id="how-long" class="govuk-heading-m" style="margin-bottom: 20px;">How long it takes</h2>
+      <p class="govuk-body" style="margin-bottom: 15px;">APHA reviews each application individually and aims to process your application within 30 days. Your application may need to be reviewed by scientific advisers at either:</p>
+      <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 15px;">
+        <li>the Royal Botanical Garden, Kew – for plants</li>
+        <li>the Joint Nature Conservation Committee (JNCC) – for animals</li>
+      </ul>
+      <p class="govuk-body" style="margin-bottom: 30px;">If your application is accepted, you'll get a printed, signed and stamped permit or certificate in the post. If your application is refused, APHA will send you a letter explaining why.</p>
+
+      <h2 id="after-permit" class="govuk-heading-m" style="margin-bottom: 20px;">After you receive your permit</h2>
+      <p class="govuk-body" style="margin-bottom: 15px;">Once you have your permit, you should:</p>
+      <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 30px;">
+        <li>check all details are correct</li>
+        <li>make sure you have all required supporting documents</li>
+        <li>contact the relevant authorities in the country you're importing to or exporting from</li>
+      </ul>
+
+      <h2 id="import-export" class="govuk-heading-m" style="margin-bottom: 20px;">Importing or exporting your species</h2>
+      <p class="govuk-body" style="margin-bottom: 15px;">When importing or exporting your species, you must:</p>
+      <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 30px;">
+        <li>present your permit to customs officials</li>
+        <li>ensure your specimens are properly packaged and labelled</li>
+        <li>follow any specific requirements for the species you're moving</li>
+      </ul>
+
+      <h2 id="returned-goods" class="govuk-heading-m" style="margin-bottom: 20px;">Returned goods</h2>
+      <p class="govuk-body" style="margin-bottom: 15px;">If your CITES specimen has been exported from Great Britain but is rejected by the importing country, contact APHA at wildlife.licensing@apha.gov.uk to let them know it's been rejected. You'll need to get CITES documents to re-import the items into Great Britain. When contacting APHA, you need to supply:</p>
+      <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 30px;">
+        <li>evidence that the specimen was legally exported from Great Britain</li>
+        <li>the reason the importing country has rejected it</li>
+      </ul>
+
+      <h2 id="marking" class="govuk-heading-m" style="margin-bottom: 20px;">Marking specimens</h2>
+      <p class="govuk-body" style="margin-bottom: 15px;">You must mark specimens according to European regulation Article 66 of EC Reg 865/2006. The marking needed depends on what the specimen is.</p>
+      <p class="govuk-body" style="margin-bottom: 15px;">Most live specimens must have one of the following:</p>
+      <ul class="govuk-list govuk-list--bullet" style="margin-bottom: 30px;">
+        <li>an International Organization for Standardization (ISO) compliant, uniquely numbered microchip</li>
+        <li>a uniquely numbered, seamless closed ring for birds (check how to register and mark birds of prey)</li>
+      </ul>
+
+      <h2 id="help" class="govuk-heading-m" style="margin-bottom: 20px;">Get help</h2>
+      <p class="govuk-body" style="margin-bottom: 30px;">If you need further advice or support with your application, contact APHA at wildlife.licensing@apha.gov.uk.</p>
+
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <div class="app-related-items" style="border-top: 2px solid #1d70b8; padding-top: 15px;">
+        <h2 class="govuk-heading-s" style="margin-bottom: 15px;">Related content</h2>
+        <ul class="govuk-list" style="margin-bottom: 0;">
+          <li><a href="#" class="govuk-link">Commercial use of endangered species: check if you need an Article 10 CITES certificate</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+{% endblock %} 

--- a/app/views/alpha-sprint-18/confirm-delete-academy.html
+++ b/app/views/alpha-sprint-18/confirm-delete-academy.html
@@ -1,0 +1,51 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Confirm delete academy" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form class="form" action="delete-academy-handler" method="post">
+      <input type="hidden" name="academy-index" value="{{ data['index'] }}">
+      
+      {{ govukRadios({
+        classes: "govuk-radios",
+        idPrefix: "confirm-delete",
+        name: "confirm-delete",
+        fieldset: {
+          legend: {
+            text: "Do you want to remove this academy?",
+            classes: "govuk-fieldset__legend--xl",
+            isPageHeading: true
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            value: "no",
+            text: "No"
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/confirm-delete-declaration.html
+++ b/app/views/alpha-sprint-18/confirm-delete-declaration.html
@@ -1,0 +1,51 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Confirm delete declaration" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form class="form" action="delete-declaration-handler" method="post">
+      <input type="hidden" name="declaration-index" value="{{ data['index'] }}">
+      
+      {{ govukRadios({
+        classes: "govuk-radios",
+        idPrefix: "confirm-delete",
+        name: "confirm-delete",
+        fieldset: {
+          legend: {
+            text: "Do you want to remove this declaration?",
+            classes: "govuk-fieldset__legend--xl",
+            isPageHeading: true
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            value: "no",
+            text: "No"
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/confirm-delete-member-to-remove.html
+++ b/app/views/alpha-sprint-18/confirm-delete-member-to-remove.html
@@ -1,0 +1,54 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Confirm delete member to remove" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to Members",
+    href: "members-summary",
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <form action="members-summary" method="post">
+      
+      {{ govukRadios({
+        name: "confirm-delete-member-to-remove",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Members</span>
+            Are you sure you want to remove ' + data['members-to-remove'][data.index].name + '?',
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes, remove from list",
+            checked: data["confirm-delete-member-to-remove"] === "yes"
+          },
+          {
+            value: "no",
+            text: "No, keep on list",
+            checked: data["confirm-delete-member-to-remove"] === "no"
+          }
+        ]
+      }) }}
+
+      <input type="hidden" name="delete-member-to-remove" value="{{ data.index }}">
+      
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+      
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/confirm-delete-member.html
+++ b/app/views/alpha-sprint-18/confirm-delete-member.html
@@ -1,0 +1,54 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Confirm delete member" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to Members",
+    href: "members-summary",
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <form action="members-summary" method="post">
+      
+      {{ govukRadios({
+        name: "confirm-delete-member",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Members</span>
+            Are you sure you want to remove ' + data['members-to-add'][data.index].name + '?',
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes, remove member",
+            checked: data["confirm-delete-member"] === "yes"
+          },
+          {
+            value: "no",
+            text: "No, keep member",
+            checked: data["confirm-delete-member"] === "no"
+          }
+        ]
+      }) }}
+
+      <input type="hidden" name="delete-member" value="{{ data.index }}">
+      
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+      
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/contributor-invite.html
+++ b/app/views/alpha-sprint-18/contributor-invite.html
@@ -1,0 +1,48 @@
+{% extends "layouts/main.html" %}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageName="Invite contributor" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "contributors-home"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Invite contributor
+    </h1>
+
+    <form action="contributor-invite-handler" method="post">
+      {{ govukInput({
+        label: {
+          text: "Email address",
+          classes: "govuk-label--m",
+          isPageHeading: false
+        },
+        hint: {
+          text: "Enter the email address of the person you want to invite as a contributor"
+        },
+        id: "contributor-email",
+        name: "contributor-email",
+        type: "email",
+        autocomplete: "email",
+        spellcheck: false
+      }) }}
+
+      {{ govukButton({
+        text: "Send email invite"
+      }) }}
+    </form>
+
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/contributors-home.html
+++ b/app/views/alpha-sprint-18/contributors-home.html
@@ -1,0 +1,95 @@
+{% extends "layouts/main.html" %}
+
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageName="Invite contributors" %}
+
+{% block beforeContent %}
+  {% if data['new-application-started'] %}
+    {{ govukBackLink({
+      text: "Back",
+      href: "javascript:window.history.back()",
+      classes: "govuk-!-margin-top-6"
+    }) }}
+  {% else %}
+    {{ govukBackLink({
+      text: "Back to application task list",
+      href: "application-task-list?ref=" + data.application.reference,
+      classes: "govuk-!-margin-top-6"
+    }) }}
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    {% if success %}
+      {% set html %}
+        <h3 class="govuk-notification-banner__heading">
+          {{ removedAcademy }} has been removed
+        </h3>
+      {% endset %}
+
+      {{ govukNotificationBanner({
+        type: "success",
+        html: html
+      }) }}
+    {% endif %}
+
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="invite-contributors">
+      Invite contributors
+    </h1>
+
+    <p class="govuk-body">
+      You can invite people to help you complete your application by providing their email address and name.</p>
+    <p class="govuk-body">
+      They must have a DfE Sign-in account. Once a contributor joins, they will be able to view and edit the application and see each contributor's email address.
+    </p>
+    {% if data['new-application-started'] %}
+      <p class="govuk-body">
+        You can add contributors now or later.
+      </p>
+    {% endif %}
+
+    <div class="govuk-button-group govuk-!-margin-top-9">
+      <a href="contributor-invite" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+        Add a contributor
+      </a>
+      {% if data['new-application-started'] %}
+        <a href="application-task-list" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+          Proceed to the application form
+        </a>
+      {% endif %}
+    </div>
+
+    <h2 class="govuk-heading-l govuk-!-margin-bottom-3">
+      Current contributors
+    </h2>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Email address</th>
+          <th scope="col" class="govuk-table__header">Name</th>
+          <th scope="col" class="govuk-table__header">Action</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        {% for contributor in data.contributors %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ contributor.email }}</td>
+          <td class="govuk-table__cell">{{ contributor.name }}</td>
+          <td class="govuk-table__cell">
+            <a href="#" class="govuk-link">Remove</a>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/dashboard.html
+++ b/app/views/alpha-sprint-18/dashboard.html
@@ -1,0 +1,90 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full govuk-!-margin-bottom-6">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-9">
+      Your applications
+    </h1>
+    <p class="govuk-body">If you start an application, you will be the lead applicant for it.</p>
+    <form action="application-task-list?ref=240315-ABC34" method="post">
+      <button class="govuk-button govuk-!-margin-bottom-9" type="submit">Start new application</button>
+    </form>
+    <h2 class="govuk-heading-l govuk-!-margin-bottom-3">
+      Applications in progress
+    </h2>
+
+    {% if data.userType === 'lead' %}
+    {% if newApplication %}
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Reference number</th>
+            <th scope="col" class="govuk-table__header">Date started</th>
+            <th scope="col" class="govuk-table__header">Status</th>
+            <th scope="col" class="govuk-table__header">Action</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">{{ newApplication.reference }}</td>
+              <td class="govuk-table__cell">{{ newApplication.dateStarted }}</td>
+              <td class="govuk-table__cell">
+                <strong class="govuk-tag govuk-tag--blue">
+                  {{ newApplication.status }}
+                </strong>
+              </td>
+              <td class="govuk-table__cell">
+                {% if newApplication.status === 'Submitted' %}
+                  <a href="check-your-answers?ref={{ newApplication.reference }}" class="govuk-link">View application</a>
+                {% else %}
+                <a href="application-task-list?ref={{ newApplication.reference }}" class="govuk-link">Continue application</a>
+                {% endif %}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      {% else %}
+        <p class="govuk-body">You have no applications in progress.</p>
+      {% endif %}
+    {% else %}
+      {% if contributorApplication %}
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Reference number</th>
+              <th scope="col" class="govuk-table__header">Date started</th>
+              <th scope="col" class="govuk-table__header">Status</th>
+              <th scope="col" class="govuk-table__header">Action</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">{{ contributorApplication.reference }}</td>
+              <td class="govuk-table__cell">{{ contributorApplication.dateStarted }}</td>
+              <td class="govuk-table__cell">
+                <strong class="govuk-tag govuk-tag--blue">
+                  {{ contributorApplication.status }}
+                </strong>
+              </td>
+              <td class="govuk-table__cell">
+                {% if contributorApplication.status === 'Submitted' %}
+                  <a href="check-your-answers?ref={{ contributorApplication.reference }}" class="govuk-link">View application</a>
+                {% else %}
+                  <a href="application-task-list?ref={{ contributorApplication.reference }}" class="govuk-link">Continue application</a>
+          {% endif %}
+              </td>
+            </tr>
+        </tbody>
+      </table>
+    {% else %}
+      <p class="govuk-body">You have no applications in progress.</p>
+    {% endif %}
+    {% endif %}
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/alpha-sprint-18/declaration-form.html
+++ b/app/views/alpha-sprint-18/declaration-form.html
@@ -1,0 +1,112 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Declaration form" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-l">Declaration from academy trust chair</span>
+    <h1 class="govuk-heading-xl">Declaration form</h1>
+  </div>
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="declaration-form-handler" method="post">
+
+        {% if declarationIndex !== undefined %}
+        <input type="hidden" name="declaration-index" value="{{ declarationIndex }}">
+        {% endif %}
+
+        <p class="govuk-body">I hereby certify that the information entered in this form is correct.</p> 
+
+        <p class="govuk-body">I understand that any decision made by the Regional Director on the basis of this information may be rendered null and void if the academy trust is found to have supplied inaccurate information.</p> 
+
+        <p class="govuk-body">I understand that no changes should be made to the trust's articles of association or other trust documents until the Regional Director has approved them.</p>
+        
+        <p class="govuk-body">When considering their equalities duties, the trust board decided that: </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>The Secretary of State's decision is unlikely to disproportionately affect any particular person or group who share protected characteristics </li>
+          <li>There are some impacts, but on balance the changes will not disproportionately affect any particular person or group who share protected characteristics </li>
+        </ul>
+
+        <p class="govuk-body">I confirm that the trust's adopted policies and practices fulfil their equalities duties under the Equality Act 2010.</p>
+
+        <h2 class="govuk-heading-m govuk-!-margin-top-9 govuk-!-margin-bottom-3">Name of the academy trust</h2>
+        <p class="govuk-body-l">{{ existingDeclaration.trust.name if existingDeclaration else trustName }}</p>
+
+        <div class="govuk-form-group govuk-!-margin-top-6">
+          <h2 class="govuk-label-wrapper">
+            <label class="govuk-label govuk-label--m" for="declaration-form-chair-of-trustees">
+              Chair of trustees of which academy trust
+            </label>
+          </h2>
+          <input class="govuk-input govuk-input--width-20" id="declaration-form-chair-of-trustees" name="declarationFormChairOfTrustees" type="text" value="{{ existingDeclaration.chairOfTrustees if existingDeclaration else '' }}">
+        </div>
+        
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="passport-issued-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h1 class="govuk-fieldset__heading">
+                Date of declaration
+              </h1>
+            </legend>
+            <div id="passport-issued-hint" class="govuk-hint">
+              For example, 27 3 2007
+            </div>
+            <div class="govuk-date-input" id="passport-issued">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="passport-issued-day">
+                    Day
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="passport-issued-day" name="passport-issued-day" type="text" inputmode="numeric" value="{{ existingDeclaration.dateOfDeclaration.day if existingDeclaration else '' }}">
+                </div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="passport-issued-month">
+                    Month
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="passport-issued-month" name="passport-issued-month" type="text" inputmode="numeric" value="{{ existingDeclaration.dateOfDeclaration.month if existingDeclaration else '' }}">
+                </div>
+              </div>
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <label class="govuk-label govuk-date-input__label" for="passport-issued-year">
+                    Year
+                  </label>
+                  <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="passport-issued-year" name="passport-issued-year" type="text" inputmode="numeric" value="{{ existingDeclaration.dateOfDeclaration.year if existingDeclaration else '' }}">
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class="govuk-button-group govuk-!-margin-top-9">
+          <button type="submit" class="govuk-button" data-module="govuk-button">
+            {% if existingDeclaration %}Update{% else %}Sign the declaration{% endif %}
+          </button>
+          {% if existingDeclaration %}
+          <a href="confirm-delete-declaration?index={{ declarationIndex }}" class="govuk-button govuk-button--warning" data-module="govuk-button">
+            Delete the declaration
+          </a>
+          {% else %}
+          <a href="declaration-summary" class="govuk-button govuk-button--warning" data-module="govuk-button">
+            Discard
+          </a>
+          {% endif %}
+        </div>
+      </form>
+      
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/alpha-sprint-18/declaration-summary.html
+++ b/app/views/alpha-sprint-18/declaration-summary.html
@@ -1,0 +1,93 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Declaration from academy trust chair summary" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "application-task-list?ref=" + data.application.reference,
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="declaration">
+      Declaration from academy trust chair
+    </h1>
+
+    <p class="govuk-body govuk-!-margin-bottom-9">Each academy trust involved must complete a declaration. You cannot manually add a declaration. You need to complete the <a class="govuk-link" href="incoming-trust-summary">Trust details</a> task and the <a class="govuk-link" href="academies-to-transfer">Academies to transfer</a> task in order to see the declaration forms.</p>
+
+    <h2 class="govuk-heading-m">Declaration form for the incoming trust</h2>
+    {% if data.selectedTrust and data.selectedTrust.name %}
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          {{ data.selectedTrust.name }}
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <strong class="govuk-tag {% if incomingTrustStatus === 'Signed' %}govuk-tag--green{% else %}govuk-tag--blue{% endif %}">
+            {{ incomingTrustStatus }}
+          </strong>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="declaration-form?trust={{ data.selectedTrust.name | urlencode }}">
+            View details<span class="govuk-visually-hidden"> declaration for {{ data.selectedTrust.name }}</span>
+          </a>
+        </dd>
+      </div>
+    </dl>
+    {% else %}
+    <p class="govuk-body">You need to add an incoming trust in the <a class="govuk-link" href="incoming-trust-summary">Trust details</a> task first.</p>
+    {% endif %}
+
+    <h2 class="govuk-heading-m">Declaration forms for the outgoing trusts</h2>
+    {% if uniqueOutgoingTrusts and uniqueOutgoingTrusts.length > 0 %}
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      {% for trust in uniqueOutgoingTrusts %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          {{ trust }}
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <strong class="govuk-tag {% if outgoingTrustsStatus[trust] === 'Signed' %}govuk-tag--green{% else %}govuk-tag--blue{% endif %}">
+            {{ outgoingTrustsStatus[trust] or 'Not signed yet' }}
+          </strong>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="declaration-form?trust={{ trust | urlencode }}">
+            View details<span class="govuk-visually-hidden"> declaration for {{ trust }}</span>
+          </a>
+        </dd>
+      </div>
+      {% endfor %}
+    </dl>
+    {% else %}
+    <p class="govuk-body">You need to add academies in the <a class="govuk-link" href="academies-to-transfer">Academies to transfer</a> task first.</p>
+    {% endif %}
+
+    <form action="application-task-list" method="post">
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      <div class="govuk-form-group govuk-!-margin-top-9">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="declaration-status" name="declaration-status" type="checkbox" value="Complete" {% if data['declaration-status'] %}checked{% endif %}>
+            <label class="govuk-label govuk-checkboxes__label" for="declaration-status">
+              Mark this section as complete, you can still make changes later
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/declaration-trust-confirmation.html
+++ b/app/views/alpha-sprint-18/declaration-trust-confirmation.html
@@ -1,0 +1,51 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Confirm trust" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" action="declaration-trust-confirmation-handler" method="post">
+      {{ govukRadios({
+        classes: "govuk-radios",
+        idPrefix: "confirm-trust",
+        name: "confirm-trust",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Declaration from academy trust chair</span>
+            Is this the right trust?',
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--xl"
+          }
+        },
+        hint: {
+          html: hintHtml
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            value: "no",
+            text: "No"
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+
+  </div>
+</div>
+{% endblock %} 

--- a/app/views/alpha-sprint-18/declaration-trust-search-results.html
+++ b/app/views/alpha-sprint-18/declaration-trust-search-results.html
@@ -1,0 +1,63 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Trust search results" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" action="declaration-trust-confirmation" method="post">
+      {{ govukRadios({
+        idPrefix: "selected-trust",
+        name: "selected-trust",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Declaration from academy trust chair</span>
+            Select a trust',
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--xl"
+          }
+        },
+        hint: {
+          text: "3 trusts found"
+        },
+        items: [
+          {
+            value: '{"name": "Bright Futures Educational Trust", "ref": "TR00123", "companies": "07695402"}',
+            text: "Bright Futures Educational Trust",
+            hint: {
+              text: "TRN: TR00123\nUKPRN: 07695402"
+            }
+          },
+          {
+            value: '{"name": "United Learning Trust", "ref": "TR00456", "companies": "04439859"}',
+            text: "United Learning Trust",
+            hint: {
+              text: "TRN: TR00456\nUKPRN: 04439859"
+            }
+          },
+          {
+            value: '{"name": "The Harris Federation", "ref": "TR00789", "companies": "06228587"}',
+            text: "The Harris Federation",
+            hint: {
+              text: "TRN: TR00789\nUKPRN: 06228587"
+            }
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+
+  </div>
+</div>
+{% endblock %} 

--- a/app/views/alpha-sprint-18/declaration-trust-search.html
+++ b/app/views/alpha-sprint-18/declaration-trust-search.html
@@ -1,0 +1,38 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Search for a trust" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" action="declaration-trust-search-results" method="post">
+      {{ govukInput({
+        label: {
+          html: '<span class="govuk-caption-l">Declaration from academy trust chair</span>
+          Search for the trust by name or reference number',
+          classes: "govuk-label--xl",
+          isPageHeading: true
+        },
+        hint: {
+          text: "For example, search by trust reference number (TRN) or UK provider reference number (UKPRN)"
+        },
+        id: "declaration-search",
+        name: "declaration-search"
+      }) }}
+
+      {{ govukButton({
+        text: "Search"
+      }) }}
+    </form>
+
+  </div>
+</div>
+{% endblock %} 

--- a/app/views/alpha-sprint-18/finance-approach.html
+++ b/app/views/alpha-sprint-18/finance-approach.html
@@ -1,0 +1,42 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What will be your approach" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="finance-summary" method="post">
+
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Finance</span>
+            What will be your approach to managing schools you are intending to take on which currently have deficits (if applicable)?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          maxlength: 4000,
+          id: "create-new-project-academy-finance-approach",
+          name: "create-new-project-academy-finance-approach",
+          value: data["create-new-project-academy-finance-approach"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/alpha-sprint-18/finance-how-to-finance-trust.html
+++ b/app/views/alpha-sprint-18/finance-how-to-finance-trust.html
@@ -1,0 +1,41 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="How will the trust be financed" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="finance-summary" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Finance</span>
+            How will the trust be financed and how do you intend to finance the growth of the trust over the next 3 years (if applicable)?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          maxlength: 4000,
+          id: "create-new-project-academy-finance-how-to-finance-trust",
+          name: "create-new-project-academy-finance-how-to-finance-trust",
+          value: data["create-new-project-academy-finance-how-to-finance-trust"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/alpha-sprint-18/finance-steps.html
+++ b/app/views/alpha-sprint-18/finance-steps.html
@@ -1,0 +1,42 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What steps will you take" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form class="form" action="finance-summary" method="post">
+
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Finance</span>
+            What steps will you take to ensure your financial model is sustainable?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          maxlength: 4000,
+          id: "create-new-project-academy-finance-steps",
+          name: "create-new-project-academy-finance-steps",
+          value: data["create-new-project-academy-finance-steps"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/alpha-sprint-18/finance-summary.html
+++ b/app/views/alpha-sprint-18/finance-summary.html
@@ -1,0 +1,90 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Finance" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "application-task-list?ref=" + data.application.reference,
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="finance">
+      Finance
+    </h1>
+
+    <p class="govuk-body eat-transfer__task-owner-box">
+      {{ taskOwnerDisplay }} <a class="govuk-link" href="task-owner-update?task=finance">Change</a>
+    </p>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          How will the trust be financed and how do you intend to finance the growth of the trust over the next 3 years (if applicable)?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['create-new-project-academy-finance-how-to-finance-trust'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="finance-how-to-finance-trust">
+            Change<span class="govuk-visually-hidden"> how will the trust be financed</span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          What is the approach to managing schools you are intending to take on which currently have deficits (if applicable)?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['create-new-project-academy-finance-approach'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="finance-approach">
+            Change<span class="govuk-visually-hidden"> what is the approach</span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          What steps will you take to ensure your financial model is sustainable?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['create-new-project-academy-finance-steps'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="finance-steps">
+            Change<span class="govuk-visually-hidden"> what steps will you take</span>
+          </a>
+        </dd>
+      </div>
+    </dl>
+    
+
+    <form action="application-task-list" method="post">
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="finance-status" name="finance-status" type="checkbox" value="Complete" {% if data['finance-status'] %}checked{% endif %}>
+            <label class="govuk-label govuk-checkboxes__label" for="finance-status">
+              Mark this section as complete, you can still make changes later
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/governance-structure-model.html
+++ b/app/views/alpha-sprint-18/governance-structure-model.html
@@ -1,0 +1,175 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What will be the trust's governance structure and how will it be implemented?" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    {% if data['file-upload-success'] %}
+      <div id="upload-success-banner" class="govuk-notification-banner govuk-notification-banner--success" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Success
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <p class="govuk-notification-banner__heading">File uploaded successfully</p>
+          <p class="govuk-body">Your governance structure document has been uploaded.</p>
+        </div>
+      </div>
+    {% endif %}
+
+    {% if data['file-delete-success'] %}
+      <div id="delete-success-banner" class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <p class="govuk-notification-banner__heading">File deleted successfully</p>
+          <p class="govuk-body">{{ data['deleted-file-name'] }} has been removed.</p>
+        </div>
+      </div>
+    {% endif %}
+
+    <form action="governance-structure-model-handler" method="post" enctype="multipart/form-data">
+
+        {{ govukFileUpload({
+          label: {
+            html: '<span class="govuk-caption-l">Governance structure</span>
+            Governance structure after the transfer',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          hint: {
+            html: '<p class="govuk-body">Upload a PDF of an A4 diagram. Give the file a clear, descriptive name.</p>'
+          },
+          id: "governance-structure-file",
+          name: "governance-structure-file",
+          value: data["governance-structure-file"]
+        }) }}
+
+        {{ govukButton({
+          text: "Upload file"
+        }) }}
+
+      </form>
+
+    {% if data['governance-structure-files'] and data['governance-structure-files'].length > 0 %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-9">Uploaded files</h2>
+      
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">File name</th>
+            <th scope="col" class="govuk-table__header">File size</th>
+            <th scope="col" class="govuk-table__header">File type</th>
+            <th scope="col" class="govuk-table__header">Action</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          {% for file in data['governance-structure-files'] %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <a href="download-governance-file/{{ loop.index0 }}" class="govuk-link" target="_blank" rel="noopener noreferrer">
+                  <strong>{{ file.name }}</strong>
+                </a>
+              </td>
+              <td class="govuk-table__cell">
+                {{ (file.size / 1024 / 1024).toFixed(2) }} MB
+              </td>
+              <td class="govuk-table__cell">
+                {{ file.type }}
+              </td>
+              <td class="govuk-table__cell">
+                <form action="delete-governance-file" method="post" style="display: inline;">
+                  <input type="hidden" name="file-index" value="{{ loop.index0 }}">
+                  {{ govukButton({
+                    text: "Delete",
+                    classes: "govuk-button--warning govuk-button--small",
+                    type: "submit"
+                  }) }}
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-9">Uploaded files</h2>
+      
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">File name</th>
+            <th scope="col" class="govuk-table__header">File size</th>
+            <th scope="col" class="govuk-table__header">File type</th>
+            <th scope="col" class="govuk-table__header">Action</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td colspan="4" class="govuk-table__cell govuk-body govuk-!-text-align-center">
+              No files uploaded yet
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    {% endif %}
+
+    <div class="govuk-button-group govuk-!-margin-top-9">
+      <form action="governance-structure" method="post">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+    </div>
+    
+  </div>
+</div>
+
+<script>
+  // Clear banner flags when page loads (for refresh)
+  document.addEventListener('DOMContentLoaded', function() {
+    clearBannerFlags();
+  });
+
+  // Clear banner flags when continue button is clicked (for navigation)
+  document.addEventListener('DOMContentLoaded', function() {
+    const continueForm = document.querySelector('form[action="governance-structure"]');
+    if (continueForm) {
+      continueForm.addEventListener('submit', function() {
+        clearBannerFlags();
+      });
+    }
+  });
+
+  // Function to clear both upload and delete success flags
+  function clearBannerFlags() {
+    fetch('clear-upload-success-flag', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      }
+    });
+    
+    fetch('clear-delete-success-flag', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      }
+    });
+  }
+</script>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/governance-structure.html
+++ b/app/views/alpha-sprint-18/governance-structure.html
@@ -1,0 +1,109 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Governance structure" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "application-task-list?ref=" + data.application.reference,
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="governance-structure">
+      Governance structure
+    </h1>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Governance structure after the transfer
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {% if data['governance-structure-files'] and data['governance-structure-files'].length > 0 %}
+            {% for file in data['governance-structure-files'] %}
+              <p class="govuk-body">
+                <a href="download-governance-file/{{ loop.index0 }}" class="govuk-link" target="_blank" rel="noopener noreferrer">
+                  <strong>{{ file.name }}</strong>
+                </a>
+              </p>
+              <p class="govuk-body govuk-!-font-size-14">
+                File size: {{ (file.size / 1024 / 1024).toFixed(2) }} MB
+              </p>
+              <p class="govuk-body govuk-!-font-size-14">
+                File type: {{ file.type }}
+              </p>
+              {% if not loop.last %}
+                <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-4 govuk-!-margin-bottom-4">
+              {% endif %}
+            {% endfor %}
+          {% else %}
+            <p class="govuk-body">No files uploaded</p>
+          {% endif %}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="governance-structure-model">
+            Manage files<span class="govuk-visually-hidden"> governance structure files</span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Has the trust confirmed everyone who will be on the governance team after the transfer?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {% if data['governance-team-confirmed'] %}
+            <p class="govuk-body">{{ data['governance-team-confirmed'] }}</p>
+          {% endif %}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="governance-team-confirmation">
+            Change<span class="govuk-visually-hidden"> governance team confirmation</span>
+          </a>
+        </dd>
+      </div>
+      {% if data['governance-team-confirmed'] === 'No' and data['governance-team-explanation'] %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Tell us about anyone who is considering joining the governance team
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body">{{ data['governance-team-explanation'] }}</p>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="governance-team-explanation">
+            Change<span class="govuk-visually-hidden"> governance team explanation</span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
+    </dl>
+    
+
+    <form action="application-task-list" method="post">
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="governance-structure-status" name="governance-structure-status" type="checkbox" value="Complete" {% if data['governance-structure-status'] %}checked{% endif %}>
+            <label class="govuk-label govuk-checkboxes__label" for="governance-structure-status">
+              Mark this section as complete, you can still make changes later
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/governance-team-confirmation.html
+++ b/app/views/alpha-sprint-18/governance-team-confirmation.html
@@ -1,0 +1,52 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Has the trust confirmed everyone who will be on the governance team after the transfer?" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="governance-team-confirmation-handler" method="post">
+
+        {{ govukRadios({
+          name: "governance-team-confirmed",
+          fieldset: {
+            legend: {
+              html: '<span class="govuk-caption-l">Governance structure</span>
+              Has the trust confirmed everyone who will be on the governance team after the transfer?',
+              classes: "govuk-fieldset__legend--l",
+              isPageHeading: true
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes",
+              checked: data["governance-team-confirmed"] === "Yes"
+            },
+            {
+              value: "No",
+              text: "No",
+              checked: data["governance-team-confirmed"] === "No"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/governance-team-explanation.html
+++ b/app/views/alpha-sprint-18/governance-team-explanation.html
@@ -1,0 +1,41 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Tell us about anyone who is considering joining the governance team" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="governance-structure" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Governance structure</span>
+            Tell us about anyone who is considering joining the governance team',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          maxlength: 4000,
+          id: "governance-team-explanation",
+          name: "governance-team-explanation",
+          value: data["governance-team-explanation"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/govuk-guide-for-schools.html
+++ b/app/views/alpha-sprint-18/govuk-guide-for-schools.html
@@ -1,0 +1,442 @@
+{% extends "alpha-sprint-7/layouts/govuk.html" %}
+
+{% set pageName="Convert to an academy: guide for schools" %}
+
+{% block beforeContent %}
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="/">Home</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="#">Education, training and skills</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="#">Running and managing a school</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="#">Setting up or changing the status of a school</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="#">Set up or convert to an academy</a>
+      </li>
+    </ol>
+  </div>
+{% endblock %}
+
+{% block content %}
+
+<style>
+  /* GOV.UK specific styles */
+  .gem-c-organisation-logo {
+    font-size: 18px;
+    line-height: 1.11111;
+    font-family: "GDS Transport", arial, sans-serif;
+    font-weight: 400;
+    margin-bottom: 30px;
+    padding: 5px 0;
+    color: #0b0c0c;
+  }
+
+  .gem-c-organisation-logo__container {
+    text-transform: none;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+  }
+
+  .gem-c-organisation-logo__crest {
+    border-left: 2px solid #1d70b8;
+    padding-left: 10px;
+    margin-right: 10px;
+  }
+
+  .gem-c-organisation-logo__name {
+    position: relative;
+    top: -2px;
+    font-size: 24px;
+  }
+
+  .manuals-header {
+    margin-top: -10px;
+    margin-left: -30px;
+    margin-right: -30px;
+    margin-bottom: 30px;
+    padding: 45px 30px;
+    background-color: #1d70b8;
+    color: #ffffff;
+  }
+
+  .gem-c-heading {
+    margin-bottom: 15px;
+  }
+
+  .gem-c-heading--inverse {
+    color: #ffffff;
+  }
+
+  .gem-c-heading__text {
+    margin: 0;
+    padding: 0;
+  }
+
+  .govuk-heading-l {
+    color: inherit;
+  }
+
+  .gem-c-metadata {
+    margin-bottom: 20px;
+  }
+
+  .gem-c-metadata--inverse {
+    color: #ffffff;
+  }
+
+  .gem-c-metadata__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .gem-c-metadata__term,
+  .gem-c-metadata__definition {
+    display: inline-block;
+    font-family: "GDS Transport", arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.25;
+    margin: 0;
+  }
+
+  .gem-c-metadata__term {
+    min-width: 120px;
+  }
+
+  .gem-c-metadata__definition {
+    margin: 0 0 10px;
+  }
+
+  .gem-c-metadata__definition:last-child {
+    margin-bottom: 0;
+  }
+
+  .gem-c-metadata__definition a {
+    color: #ffffff;
+    text-decoration: none;
+  }
+
+  .gem-c-metadata__definition a:hover {
+    text-decoration: underline;
+  }
+
+  .gem-c-metadata__definition a:focus {
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none;
+    outline: 3px solid transparent;
+  }
+
+  .gem-c-devolved-nations {
+    padding: 10px 0;
+    border-bottom: 1px solid #b1b4b6;
+    margin-bottom: 30px;
+  }
+
+  .gem-c-devolved-nations .govuk-heading-s {
+    font-family: "GDS Transport", arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 1.25;
+    color: #505a5f;
+    margin-bottom: 0;
+  }
+
+  .gem-c-document-list {
+    color: #0b0c0c;
+    font-family: "GDS Transport", arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .gem-c-document-list__item {
+    margin-bottom: 20px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid #b1b4b6;
+    list-style: none;
+  }
+
+  .gem-c-document-list__item:last-child {
+    border-bottom: none;
+  }
+
+  .gem-c-document-list__item-title {
+    font-family: "GDS Transport", arial, sans-serif;
+    font-weight: 700;
+    font-size: 19px;
+    line-height: 1.3157894737;
+    margin: 0 0 5px;
+    padding: 0;
+  }
+
+  .gem-c-document-list__item-title a {
+    text-decoration: none;
+  }
+
+  .gem-c-document-list__item-title a:hover {
+    text-decoration: underline;
+    text-decoration-thickness: max(1px, .0625rem);
+    text-underline-offset: 0.1em;
+  }
+
+  .gem-c-document-list__item-title a:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+  }
+
+  .gem-c-document-list__item-description {
+    color: #505a5f;
+    font-family: "GDS Transport", arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+    margin: 0;
+    padding: 0;
+  }
+
+  .gem-c-lead-paragraph {
+    color: #0b0c0c;
+    font-family: "GDS Transport", arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 24px;
+    line-height: 1.25;
+    margin-bottom: 30px;
+  }
+
+  .gem-c-print-link {
+    display: none;
+  }
+
+  @media print {
+    .gem-c-print-link {
+      display: block;
+    }
+  }
+
+  .gem-c-search {
+    position: relative;
+    margin-bottom: 30px;
+    padding: 0;
+  }
+
+  .gem-c-search--on-govuk-blue {
+    margin-bottom: 0;
+  }
+
+  .gem-c-search__label {
+    font-family: "GDS Transport", arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.25;
+    color: #ffffff;
+    display: block;
+    margin-bottom: 5px;
+  }
+
+  .gem-c-search__item-wrapper {
+    display: table;
+    width: 100%;
+    background: #ffffff;
+  }
+
+  .js-search-input-wrapper {
+    display: table-cell;
+    position: relative;
+    vertical-align: top;
+  }
+
+  .gem-c-search__item {
+    border: 0;
+    font-family: "GDS Transport", arial, sans-serif;
+    font-size: 19px;
+    line-height: 1.25;
+    box-sizing: border-box;
+    width: 100%;
+    margin: 0;
+    padding: 6px;
+    display: block;
+    height: 40px;
+  }
+
+  .gem-c-search__submit-wrapper {
+    display: table-cell;
+    width: 1%;
+    vertical-align: top;
+  }
+
+  .gem-c-search__submit {
+    border: 0;
+    cursor: pointer;
+    position: relative;
+    padding: 0;
+    width: 40px;
+    height: 40px;
+    background-color: #1d70b8;
+    color: #ffffff;
+    font-size: 0;
+  }
+
+  .gem-c-search__submit:hover {
+    background-color: #003078;
+  }
+
+  .gem-c-search__submit:focus {
+    outline: 3px solid #ffdd00;
+    outline-offset: 0;
+  }
+
+  .gem-c-search__icon {
+    width: 40px;
+    height: 40px;
+    display: block;
+    margin: 0 auto;
+  }
+</style>
+
+<div class="publication-external">
+  <div class="gem-c-organisation-logo">
+    <a class="gem-c-organisation-logo__container" href="#">
+      <span class="gem-c-organisation-logo__crest">
+        <span class="gem-c-organisation-logo__name">Department<br>for Education</span>
+      </span>
+    </a>
+  </div>
+</div>
+
+<header class="manuals-header">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="gem-c-heading gem-c-heading--inverse">
+        <h1 class="gem-c-heading__text govuk-heading-l">
+          Convert to an academy: guide for schools
+        </h1>
+      </div>
+
+      <div class="gem-c-metadata gem-c-metadata--inverse">
+        <dl class="gem-c-metadata__list">
+          <dt class="gem-c-metadata__term">From:</dt>
+          <dd class="gem-c-metadata__definition">
+            <a href="#">Department for Education</a>
+          </dd>
+          <dt class="gem-c-metadata__term">Published</dt>
+          <dd class="gem-c-metadata__definition">26 November 2015</dd>
+          <dt class="gem-c-metadata__term">Updated:</dt>
+          <dd class="gem-c-metadata__definition">
+            31 January 2025 - <a href="#">See all updates</a>
+          </dd>
+        </dl>
+      </div>
+
+      <div class="in-manual-search">
+        <form action="/search/all">
+          <div class="gem-c-search govuk-!-display-none-print gem-c-search--on-govuk-blue">
+            <label for="search-main" class="gem-c-search__label">Search this manual</label>
+            <div class="gem-c-search__item-wrapper">
+              <div class="js-search-input-wrapper">
+                <input type="search" name="q" id="search-main" class="gem-c-search__item gem-c-search__input" title="Search" enterkeyhint="search">
+              </div>
+              <div class="gem-c-search__submit-wrapper">
+                <button class="gem-c-search__submit" type="submit">
+                  Search
+                  <svg class="gem-c-search__icon" width="27" height="27" viewBox="0 0 27 27" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                    <circle cx="12.0161" cy="11.0161" r="8.51613" stroke="currentColor" stroke-width="3"></circle>
+                    <line x1="17.8668" y1="17.3587" x2="26.4475" y2="25.9393" stroke="currentColor" stroke-width="3"></line>
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</header>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <section class="gem-c-devolved-nations">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
+        Applies to England
+      </h2>
+    </section>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">Summary</h2>
+    <p class="gem-c-lead-paragraph">
+      How to transfer an academy from one academy trust to another.
+    </p>
+
+    <p class="govuk-body">If you are the chair of trustees of a single or multi-academy trust (SAT or MAT), you must complete the following steps.</p>
+
+    <h2 class="govuk-heading-l">Contents</h2>
+
+    <ul class="gem-c-document-list">
+      <li class="gem-c-document-list__item">
+        <div class="gem-c-document-list__item-title">
+          <a class="govuk-link" href="#1-before-you-apply">1. Do due diligence</a>
+        </div>
+        <p class="gem-c-document-list__item-description">Research other academy trusts to understand if they would be a good fit for your academies.</p>
+      </li>
+      <li class="gem-c-document-list__item">
+        <div class="gem-c-document-list__item-title">
+          <a class="govuk-link" href="#2-apply-to-convert">2. Contact your trust relationship manager (TRM)</a>
+        </div>
+        <p class="gem-c-document-list__item-description">Your TRM will help you choose the right trust, and explain what the transfers process involves.</p>
+      </li>
+      <li class="gem-c-document-list__item">
+        <div class="gem-c-document-list__item-title">
+          <a class="govuk-link" href="#3-set-up-or-join">3. Discuss with your board of trustees</a>
+        </div>
+        <p class="gem-c-document-list__item-description">You must get approval from your board of trustees before submitting an application.</p>
+      </li>
+      <li class="gem-c-document-list__item">
+        <div class="gem-c-document-list__item-title">
+          <a class="govuk-link" href="#4-gather-evidence">4. Gather evidence</a>
+        </div>
+        <p class="gem-c-document-list__item-description">You will need evidence including academic performance, finance data and reasons for joining the trust.</p>
+      </li>
+      <li class="gem-c-document-list__item">
+        <div class="gem-c-document-list__item-title">
+          <a class="govuk-link" href="#5-submit-application">5. Submit your application to the Department for Education</a>
+        </div>
+        <p class="gem-c-document-list__item-description">Submit your academy transfer request, along with your supporting evidence.</p>
+      </li>
+      <li class="gem-c-document-list__item">
+        <div class="gem-c-document-list__item-title">
+          <a class="govuk-link" href="#6-wait-for-decision">6. Wait for a decision</a>
+        </div>
+        <p class="gem-c-document-list__item-description">Your application will be reviewed by an advisory board, before a regional director makes a formal decision.</p>
+      </li>
+      <li class="gem-c-document-list__item">
+        <div class="gem-c-document-list__item-title">
+          <a class="govuk-link" href="#7-complete-transfer">7. Help complete the transfer</a>
+        </div>
+        <p class="gem-c-document-list__item-description">You'll need to address several things in the delivery phase before the transfer is complete.</p>
+      </li>
+    </ul>
+
+    <div class="gem-c-print-link">
+      <button class="govuk-link govuk-body-s">Print this page</button>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/alpha-sprint-18/govuk-information-note.html
+++ b/app/views/alpha-sprint-18/govuk-information-note.html
@@ -1,0 +1,405 @@
+{% extends "alpha-sprint-7/layouts/govuk.html" %}
+
+{% set pageName="Information note for academy trusts about academy transfer" %}
+
+{% block beforeContent %}
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+          <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="/">Home</a>
+          </li>
+          <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="#">Education, training and skills</a>
+          </li>
+          <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="#">Running and managing a school</a>
+          </li>
+          <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="#">Setting up or changing the status of a school</a>
+          </li>
+    </ol>
+  </div>
+{% endblock %}
+
+{% block content %}
+
+<style>
+  /* GOV.UK specific styles */
+  .gem-c-organisation-logo {
+    font-size: 18px;
+    line-height: 1.11111;
+    font-family: "GDS Transport", arial, sans-serif;
+    font-weight: 400;
+    margin-bottom: 30px;
+    padding: 5px 0;
+    color: #0b0c0c;
+  }
+
+  .gem-c-organisation-logo__container {
+    text-transform: none;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+  }
+
+  .gem-c-organisation-logo__crest {
+    border-left: 2px solid #1d70b8;
+    padding-left: 10px;
+    margin-right: 10px;
+  }
+
+  .gem-c-organisation-logo__name {
+    position: relative;
+    top: -2px;
+    font-size: 24px;
+  }
+
+  .gem-c-inverse-header {
+    padding: 0;
+    background-color: #1d70b8;
+    color: #ffffff;
+    margin-bottom: 40px;
+    margin-top: -10px;
+    margin-left: -30px;
+    margin-right: -30px;
+    padding: 45px 30px;
+  }
+
+  .gem-c-inverse-header .govuk-caption-xl {
+    color: #ffffff;
+    margin-bottom: 15px;
+  }
+
+  .gem-c-inverse-header .govuk-heading-xl {
+    color: #ffffff;
+    margin: 0;
+    margin-bottom: 10px;
+  }
+
+  .gem-c-inverse-header__subtext {
+    font-family: "GDS Transport", arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-size: 19px;
+    line-height: 1.25;
+    margin: 15px 0 0;
+    color: #ffffff;
+  }
+
+  .gem-c-inverse-header__content {
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  .gem-c-govspeak {
+    color: #0b0c0c;
+    font-family: "GDS Transport", arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  
+  .gem-c-contents-list {
+    position: sticky;
+    top: 20px;
+    margin: 0;
+    padding: 20px;
+    background-color: #f8f8f8;
+    border: 1px solid #b1b4b6;
+  }
+
+  .gem-c-contents-list__title {
+    color: #0b0c0c;
+    font-family: "GDS Transport", arial, sans-serif;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 1.25;
+    margin: 0;
+  }
+
+  .gem-c-contents-list__list {
+    color: #0b0c0c;
+    font-family: "GDS Transport", arial, sans-serif;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 1.25;
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  .gem-c-contents-list__list-item {
+    padding-top: 10px;
+    line-height: 1.3;
+    list-style-type: none;
+  }
+
+  .gem-c-contents-list__link {
+    text-decoration: none;
+  }
+
+  .gem-c-contents-list__link:hover,
+  .gem-c-contents-list__link:active {
+    text-decoration: underline;
+  }
+
+  .gem-c-contents-list__link:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none;
+  }
+
+  .call-to-action {
+    margin: 2em 0;
+    padding: 2em;
+    background-color: #f3f2f1;
+  }
+
+  .govuk-heading-xl {
+    margin-top: 30px;
+    margin-bottom: 30px;
+  }
+
+  .govuk-caption-xl {
+    font-family: "GDS Transport", arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-weight: 400;
+    font-size: 27px;
+    line-height: 1.11111;
+    display: block;
+    margin-bottom: 5px;
+    color: #505a5f;
+  }
+
+  .govuk-inset-text {
+    font-family: "GDS Transport", arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-weight: 400;
+    font-size: 19px;
+    line-height: 1.25;
+    color: #0b0c0c;
+    padding: 15px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+    clear: both;
+    border-left: 10px solid #b1b4b6;
+  }
+
+  abbr {
+    text-decoration: none;
+    cursor: help;
+  }
+
+  .footnotes {
+    border-top: 1px solid #b1b4b6;
+    margin-top: 30px;
+    padding-top: 10px;
+  }
+
+  .footnotes ol {
+    padding-left: 20px;
+  }
+
+  .footnotes li {
+    margin-bottom: 10px;
+  }
+
+  .gem-c-devolved-nations {
+    padding: 10px 0;
+    border-bottom: 1px solid #b1b4b6;
+    margin-bottom: 30px;
+  }
+
+  .gem-c-devolved-nations .govuk-heading-s {
+    font-family: "GDS Transport", arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 1.25;
+    color: #505a5f;
+    margin-bottom: 0;
+  }
+</style>
+  
+    <div class="publication-external">
+  <div class="gem-c-organisation-logo">
+    <a class="gem-c-organisation-logo__container" href="#">
+      <span class="gem-c-organisation-logo__crest">
+        <span class="gem-c-organisation-logo__name">Department<br>for Education</span>
+      </span>
+  </a>
+  </div>
+    </div>
+  
+<header class="gem-c-inverse-header">
+  <div class="gem-c-inverse-header__content">
+    <span class="govuk-caption-xl">Guidance</span>
+    <h1 class="govuk-heading-xl">Information note for academy trusts about academy transfer</h1>
+    <p class="gem-c-inverse-header__subtext">Updated 22 December 2022</p>
+  </div>
+  </header>
+  
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <section class="gem-c-devolved-nations">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
+        Applies to England
+  </h2>
+  </section>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <nav class="gem-c-contents-list" aria-label="Contents">
+              <h2 class="gem-c-contents-list__title">Contents</h2>
+              <ol class="gem-c-contents-list__list">
+        <li class="gem-c-contents-list__list-item">
+          <a class="gem-c-contents-list__link" href="#academy-transfer">Academy transfer</a>
+                  </li>
+        <li class="gem-c-contents-list__list-item">
+          <a class="gem-c-contents-list__link" href="#transfer-process">Transfer process</a>
+                  </li>
+        <li class="gem-c-contents-list__list-item">
+          <a class="gem-c-contents-list__link" href="#regional-director-rd-approval">Regional director (RD) approval</a>
+                  </li>
+        <li class="gem-c-contents-list__list-item">
+          <a class="gem-c-contents-list__link" href="#due-diligence">Due diligence</a>
+                  </li>
+        <li class="gem-c-contents-list__list-item">
+          <a class="gem-c-contents-list__link" href="#delivery">Delivery</a>
+                  </li>
+              </ol>
+            </nav>
+        </div>
+        
+  <div class="govuk-grid-column-three-quarters">
+    
+  <div class="call-to-action">
+    <p>This note is designed to provide information for academy trusts involved in an academy transfer or trust closure. It does not constitute legal advice and trusts should seek independent legal advice where needed.</p>
+  </div>
+  
+    <h2 class="govuk-heading-l" id="academy-transfer">Academy transfer</h2>
+    <p class="govuk-body">An academy transfer is when an academy moves from its current trust ('the outgoing trust') to another trust ('the incoming trust'). A transfer can only happen with the agreement of the regional director (<abbr title="regional director">RD</abbr>) acting on behalf of the Secretary of State for Education. There is a range of reasons for academy transfer:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>transfer initiated by the outgoing trust – most academies that transfer between trusts do so based on a decision by the outgoing trust<sup id="fnref:1"><a href="#fn:1" class="govuk-link">[footnote 1]</a></sup>. This might be to ensure stronger school-to-school support or economies of scale, for example a single academy trust (<abbr title="single academy trust">SAT</abbr>) joining a multi-academy trust (<abbr title="multi-academy trust">MAT</abbr>). It might also be for strategic reasons, for example academies moving to MATs that are closer geographically</li>
+      <li>intervention – a small number of academies transfer each year due to intervention following, for example, an Ofsted Inadequate judgement<sup id="fnref:2"><a href="#fn:2" class="govuk-link">[footnote 2]</a></sup>. In such cases, or where there are financial, governance or safeguarding failures, <abbr title="regional directors">RDs</abbr> and the Education and Skills Funding Agency (<abbr title="Education and Skills Funding Agency">ESFA</abbr>) have the power to terminate funding agreements and transfer the academy into a new trust</li>
+    <li>trust closure – in the rare event that a trust closes, academies in the closing trust must be transferred to a new trust as part of the closure. Academies within a closing trust must be transferred even if they themselves are not otherwise eligible for intervention</li>
+  </ul>
+
+  <div class="govuk-inset-text">
+      Trusts can complete an online application to request academy transfers to another trust: <a href="https://external-applications-0c3afd1bd5f8.herokuapp.com/alpha-sprint-7/landing-page-version-1" class="govuk-link">transfer academies to another trust</a>.
+  </div>
+  
+  <p>Academy transfer remains rare. In the financial year 2021 to 2022, only 176 of the 9,900 academies moved trust. This is just 1.8% of all academies. Of these, only 14% of academies that moved trust that year were due to intervention (<a href="https://www.gov.uk/government/statistics/academy-transfers-and-funding-2021-to-2022" class="govuk-link">source: Academy transfers and funding 2021 to 2022 statistics</a>).</p>
+  
+    <p><abbr title="regional directors">RDs</abbr> will act swiftly and robustly where there is failure in an academy. <abbr title="regional directors">RDs</abbr> will assess each academy's circumstances, and the capacity of the trust, in order to decide whether an academy transfer is appropriate to bring about the necessary level of improvement and ensure the highest quality education for pupils.</p>
+  
+    <h2 class="govuk-heading-l" id="transfer-process">Transfer process</h2>
+  
+  <p>Academy transfers are approved by <abbr title="regional directors">RDs</abbr>. Prior to approval, the case will be discussed at the regional <a href="https://www.gov.uk/government/collections/advisory-boards" class="govuk-link">advisory board</a> which is an advisory body comprising members with local knowledge, expertise and experience, who are responsible for advising and challenging <abbr title="regional directors">RDs</abbr> on academy-related decisions. Following a discussion of the case at an advisory board, the <abbr title="regional director">RD</abbr> will usually decide whether to approve the incoming trust at the meeting but the <abbr title="regional director">RD</abbr> may do so after it.</p>
+  
+  <p>From the point the <abbr title="regional director">RD</abbr> approves a transfer in principle, the aspiration is for the transfer process to be completed within 6 months in straightforward cases. More complex cases may take longer. Delivery officers in the Department for Education (<abbr title="Department for Education">DfE</abbr>) are responsible for driving the process forward and supporting trusts to meet their obligations. Trusts should expect to work closely and openly with both the department and each other until the process is completed.</p>
+  
+    <h2 class="govuk-heading-l" id="regional-director-rd-approval">Regional director (<abbr title="regional director">RD</abbr>) approval</h2>
+  
+  <p>For the majority of transfers initiated by the outgoing trust, for example where there is one identified incoming trust and no sponsorship issues, <abbr title="regional director">RD</abbr> approval will typically be straightforward.</p>
+  
+  <p>In intervention cases, the department will consider potential incoming trusts. <abbr title="regional directors">RDs</abbr> reach a decision about the preferred incoming trust by considering a number of factors, including a strong track record of school improvement, governance and finance, and evidence of how the trust would support the academy in question and capacity to do so. In some cases an expression of interest process may be used. Again, this would depend on the circumstances of the individual case. The case would then be discussed at an advisory board prior to <abbr title="regional director">RD</abbr> approval.</p>
+  
+  <p>The proposed transfer and the name of the incoming trust will be announced in the advisory board agenda.</p>
+  
+  <p>Following <abbr title="regional director">RD</abbr> approval of the incoming trust, the incoming trust is expected to engage stakeholders. <abbr title="Department for Education">DfE</abbr> delivery officers can advise on how to do this.</p>
+  
+  <p>Both the outgoing and incoming trusts will be sent their respective trust agreements (sample agreements are attached at annexes A and B) by the <abbr title="Department for Education">DfE</abbr> delivery officer. These documents outline what trusts are expected to do throughout the academy transfer process. After signing and returning their trust agreements, trusts are then responsible for working together to manage the commercial and legal implications of the transfer, to a timeline agreed with the department. Final approval to transfer will be given by the department once these elements have been finalised and trusts will sign various documents to complete the transfer.</p>
+  
+  <p>Where the incoming trust will provide school improvement support to the transferring academy before the transfer, it is advisable that an agreement is prepared ahead of any such support so that both parties are clear about the expectations of the scope of the school improvement work and how any payments will be made. A recommended service level agreement is attached at annex C. This should be adapted to meet the particular needs of the transfer.</p>
+  
+    <h2 class="govuk-heading-l" id="due-diligence">Due diligence</h2>
+  
+    <p>Due diligence should be undertaken by the incoming trust to understand the academy's position. The outgoing trust must cooperate and provide all the information requested. The extent of due diligence is determined by the incoming trust. This may vary on a case by case basis, but it will usually include assessment of education provision, pupil population, finances, staffing, governance and the school buildings and estate. The incoming trust must fully assure itself that sufficient due diligence has been carried out, confirming to the department that due diligence has been completed and that the trust is aware of any ongoing issues ahead of transferring.</p>
+  
+  <p>Best practice <a href="https://www.gov.uk/government/publications/due-diligence-in-academies-and-maintained-schools" class="govuk-link">guidance on undertaking due diligence is available</a>. For intervention cases the expectation is due diligence should take around 1 month.</p>
+  
+    <p>Grant funding for transfers is by exception and is normally provided only in intervention cases. In such cases, the department will then agree an appropriate level of funding for the incoming trust to facilitate an efficient transfer<sup id="fnref:3"><a href="#fn:3" class="govuk-link">[footnote 3]</a></sup>.</p>
+  
+  <p>Trusts should be aware of the financial liabilities involved in the academy transfer process. The <a href="https://www.gov.uk/government/publications/academy-transfers-information-for-academy-trusts" class="govuk-link">information note for trusts on finances and liabilities</a> sets out the risks in more detail. It is important that trusts give due attention to this note to fully understand the potential impact on their transfer and understand the guidelines in which they must operate.</p>
+  
+  <p>The incoming trust must then sign and return the negotiating offer closure letter (a sample is attached at annex D) once all funding has been agreed. The purpose of this letter is to summarise in one place all the funding the trust will receive and to agree a transfer date. It will be sent in addition to the individual grant offers which set out the conditions of each grant.</p>
+  
+    <h2 class="govuk-heading-l" id="delivery">Delivery</h2>
+  
+    <p>Trusts should address several things in the delivery phase (after the <abbr title="regional director">RD</abbr>'s decision) before completing the transfer. These include the incoming trust engaging stakeholders and producing legal documents.</p>
+  
+  <p>Stakeholder engagement is an opportunity for:</p>
+  
+    <ul class="govuk-list govuk-list--bullet">
+    <li>the incoming and outgoing trusts to explain more about the transfer, listen to questions and address any issues</li>
+    <li>the incoming trust to meet with parents, teachers and the local community and set out its plans for the school. If relevant, this should include how the plans will support the school to improve</li>
+  </ul>
+  
+  <p>Trusts need to produce legal documents for review and clearance by the <abbr title="Department for Education">DfE</abbr> delivery officer. The outgoing and incoming trusts  need to agree and sign these. The delivery officer will set deadlines on a case by case basis. Trusts need to meet these deadlines  for the transfer to happen on the planned date.</p>
+  
+    <h3 class="govuk-heading-m" id="working-with-solicitors">Working with solicitors</h3>
+  
+  <p>Trusts are responsible for ensuring these actions take place but may wish to ask solicitors to prepare the documents on their behalf. If this is the case, trusts should ensure they understand the process and timelines and relay this to their solicitors. Trusts should provide their delivery officer with regular progress updates and ask if they are unsure about timelines or have any further questions.</p>
+  
+  <p>The key documents and actions that make up the delivery phase are:</p>
+  
+    <h3 class="govuk-heading-m" id="funding-agreement">Funding agreement</h3>
+  
+    <p>The funding agreement (<abbr title="funding agreement">FA</abbr>) provides the framework for an academy or free school to operate in. In the case of academy transfers, our preferred route for the legal transfer is novation and variation to move from the existing funding agreement documents to the new model versions. The deed of novation and variation enable the academy's existing <abbr title="funding agreement">FA</abbr> to transfer from the outgoing to incoming trust.</p>
+  
+  <p>All academies that transfer must use the latest version of the model <abbr title="funding agreement">FA</abbr>.  Where the incoming trust has a master funding agreement earlier than the latest model version, the delivery officer will ask the trust to adopt the latest model as part of the transfer process.</p>
+  
+  <p>See the latest model master and supplemental funding agreement documents on the <a href="https://www.gov.uk/government/collections/convert-to-an-academy-documents-for-schools" class="govuk-link">convert to academy: documents for schools</a> page.</p>
+  
+  <p>The deed of novation and variation will need to be drafted by the incoming trust and agreed with the outgoing trust and the department, as both trusts and the department will need to sign this document to finalise the transfer. Draft documents should be sent to the delivery officer to clear before being signed.</p>
+  
+    <h3 class="govuk-heading-m" id="commercial-transfer-agreement">Commercial transfer agreement</h3>
+  
+  <p>The commercial transfer agreement (<abbr title="commercial transfer agreement">CTA</abbr>) is used to transfer assets and liabilities (including contracts and staff) from one academy trust to another. It needs to be agreed by both the incoming and outgoing trusts. A final draft of the agreement should be shared with the delivery officer before being signed by both trusts. Trusts should contact their <abbr title="Department for Education">DfE</abbr> delivery officer for a copy of the <abbr title="commercial transfer agreement">CTA</abbr> used in transfer cases.</p>
+  
+    <h3 class="govuk-heading-m" id="transfer-of-undertakings-protection-of-employment-regulations-2006">Transfer of Undertakings (Protection of Employment) Regulations 2006</h3>
+  
+    <p>Transfer of Undertakings (Protection of Employment) Regulations 2006 (<abbr title="Transfer of Undertakings (Protection of Employment) Regulations 2006">TUPE</abbr>) allows staff to automatically transfer their terms and conditions from the outgoing to incoming trust. The incoming trust will need to work with the outgoing trust on the <abbr title="Transfer of Undertakings (Protection of Employment) Regulations 2006">TUPE</abbr> consultation. Trusts will need to confirm to the department that the <abbr title="Transfer of Undertakings (Protection of Employment) Regulations 2006">TUPE</abbr> consultation has taken place and staff have been <abbr title="Transfer of Undertakings (Protection of Employment) Regulations 2006">TUPE</abbr>'d across to the new trust.</p>
+  
+    <h3 class="govuk-heading-m" id="private-finance-initiative-pfi-contract">Private finance initiative (<abbr title="private finance initiative">PFI</abbr>) contract</h3>
+  
+  <p>Where there is a <abbr title="private finance initiative">PFI</abbr> contract in place, this will need to be transferred to the incoming trust. These should be novated to the new trust on the existing terms.</p>
+  
+    <h3 class="govuk-heading-m" id="land-transfer">Land transfer</h3>
+  
+    <p>Before an academy can transfer, the outgoing trust will need to seek the Secretary of State's consent to dispose of the land or lease to allow it to move to the new trust. To do this, the outgoing trust will need to complete <a href="https://www.gov.uk/guidance/submit-a-school-land-transaction-proposal#application-forms-for-school-land-transactions" class="govuk-link">form M - academy land transfers</a>.</p>
+  
+    <h3 class="govuk-heading-m" id="payment-information--bank-details">Payment information – bank details</h3>
+  
+    <p>To ensure that funding is paid to the incoming trust on time, accurately and securely, the department needs confirmation of the incoming trust's bank details. The form to <a href="https://www.gov.uk/government/publications/academy-bank-details-form" class="govuk-link">provide information about your banking and payments to <abbr title="Department for Education">DfE</abbr></a> should be used to do this.</p>
+  
+  <p>If the department does not receive the completed form before the deadline (as set by the delivery officer), it will result in a delay to the incoming trust receiving funding.</p>
+  
+    <h3 class="govuk-heading-m" id="insurance">Insurance</h3>
+  
+    <p>The trusts must confirm that the benefit of any insurance policies has been passed to the incoming trust. This includes confirming that the insurer was properly notified of any risk exposure. If not already members, trusts may want to consider the department's <a href="https://www.gov.uk/guidance/academies-risk-protection-arrangement-rpa" class="govuk-link">risk protection arrangement (<abbr title="risk protection arrangement">RPA</abbr>)</a> instead of commercial insurance.</p>
+  
+    <h3 class="govuk-heading-m" id="general-annual-grant-gag-payment">General annual grant (<abbr title="general annual grant">GAG</abbr>) payment</h3>
+  
+  <p>Trusts need to be aware that in the planned month of the trust transfer, they will receive the <abbr title="general annual grant">GAG</abbr> payment on the sixth working day of the month unless other arrangements have been made.</p>
+  
+    <div class="footnotes">
+    <ol>
+      <li id="fn:1">
+          <p>Voluntary transfers are also known as 'approved transfers' or 'transfer by mutual agreement'.<a href="#fnref:1" class="govuk-link">↩</a></p>
+      </li>
+      <li id="fn:2">
+          <p>These transfers are also known as 'intervention transfers' or 'enforced transfers'.<a href="#fnref:2" class="govuk-link">↩</a></p>
+      </li>
+      <li id="fn:3">
+        <p>Information about indicative grant funding levels can be found within the technical section of <a rel="external" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/726556/Academy_Transfers_and_Funding_2017_to_2018_Text.pdf" class="govuk-link">Academy transfers and funding in England (PDF, 488KB)</a>.&nbsp;<a href="#fnref:3" class="govuk-link" role="doc-backlink" aria-label="go to where this is referenced">↩</a></p>
+      </li>
+    </ol>
+  </div>
+    </div>
+  </div>
+  
+{% endblock %}

--- a/app/views/alpha-sprint-18/high-quality-and-inclusive-education-inclusive.html
+++ b/app/views/alpha-sprint-18/high-quality-and-inclusive-education-inclusive.html
@@ -1,0 +1,44 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="How will the transfer impact the trust and transferring academies" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="high-quality-and-inclusive-education-inclusive-handler" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">High-quality and inclusive education</span>
+            How will the transfer impact the trust and transferring academies?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          hint: {
+            text: "For example, if the trust and academies have pupils with similar characteristics, how these pupils will be impacted"
+          },
+          maxlength: 4000,
+          id: "high-quality-and-inclusive-education-inclusive",
+          name: "high-quality-and-inclusive-education-inclusive",
+          value: data["high-quality-and-inclusive-education-inclusive"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/high-quality-and-inclusive-education-quality.html
+++ b/app/views/alpha-sprint-18/high-quality-and-inclusive-education-quality.html
@@ -1,0 +1,41 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="How do the existing academies at the trust provide high quality and inclusive education" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="high-quality-and-inclusive-education-quality-handler" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">High-quality and inclusive education</span>
+            How do the existing academies at the trust provide high quality and inclusive education?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          maxlength: 4000,
+          id: "high-quality-and-inclusive-education-quality",
+          name: "high-quality-and-inclusive-education-quality",
+          value: data["high-quality-and-inclusive-education-quality"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/high-quality-and-inclusive-education.html
+++ b/app/views/alpha-sprint-18/high-quality-and-inclusive-education.html
@@ -1,0 +1,77 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="High-quality and inclusive education" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "application-task-list?ref=" + data.application.reference,
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="high-quality-and-inclusive-education">
+      High-quality and inclusive education
+    </h1>
+
+    <p class="govuk-body eat-transfer__task-owner-box">
+      {{ taskOwnerDisplay }} <a class="govuk-link" href="task-owner-update?task=high-quality-and-inclusive-education">Change</a>
+    </p>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          How do the existing academies at the trust provide high quality and inclusive education?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['high-quality-and-inclusive-education-quality'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="high-quality-and-inclusive-education-quality">
+            Change<span class="govuk-visually-hidden"> how do the existing academies at the trust provide high quality and inclusive education</span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          How will the transfer impact the trust and transferring academies?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['high-quality-and-inclusive-education-inclusive'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="high-quality-and-inclusive-education-inclusive">
+            Change<span class="govuk-visually-hidden"> how will the transfer impact the trust and transferring academies</span>
+          </a>
+        </dd>
+      </div>
+    </dl>
+    
+
+    <form action="application-task-list" method="post">
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="high-quality-and-inclusive-education-status" name="high-quality-and-inclusive-education-status" type="checkbox" value="Complete" {% if data['high-quality-and-inclusive-education-status'] %}checked{% endif %}>
+            <label class="govuk-label govuk-checkboxes__label" for="high-quality-and-inclusive-education-status">
+              Mark this section as complete, you can still make changes later
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/incoming-trust-confirmation.html
+++ b/app/views/alpha-sprint-18/incoming-trust-confirmation.html
@@ -1,0 +1,55 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Confirm incoming trust" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" action="incoming-trust-confirmation-handler" method="post">
+      {{ govukRadios({
+        classes: "govuk-radios",
+        idPrefix: "confirm-trust",
+        name: "confirm-trust",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Incoming trust</span>
+            Is this the right trust?',
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--xl"
+          }
+        },
+        hint: {
+          html: '<div class="govuk-inset-text">
+            <h2 class="govuk-heading-m">' + selectedTrust.name + '</h2>
+            <p class="govuk-body">TRN: ' + selectedTrust.ref + '</p>
+            <p class="govuk-body">UKPRN: ' + selectedTrust.companies + '</p>
+          </div>'
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes"
+          },
+          {
+            value: "no",
+            text: "No"
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+
+  </div>
+</div>
+{% endblock %} 

--- a/app/views/alpha-sprint-18/incoming-trust-new-trust-question.html
+++ b/app/views/alpha-sprint-18/incoming-trust-new-trust-question.html
@@ -1,0 +1,55 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="New trust question" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form class="form" action="new-trust-handler" method="post">
+      <!--
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      -->
+      {{ govukRadios({
+        classes: "govuk-radios",
+        idPrefix: "new-trust",
+        name: "new-trust",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Trust details</span>
+            Is the result of this transfer the formation of a new trust?',
+            classes: "govuk-fieldset__legend--xl",
+            isPageHeading: true
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes",
+            checked: data['new-trust'] === 'yes'
+          },
+          {
+            value: "no",
+            text: "No",
+            checked: data['new-trust'] === 'no'
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/incoming-trust-preferred-trust-question.html
+++ b/app/views/alpha-sprint-18/incoming-trust-preferred-trust-question.html
@@ -1,0 +1,52 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Preferred trust question" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" action="preferred-trust-handler" method="post">
+            <!--
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      -->
+      {{ govukRadios({
+        idPrefix: "preferred-trust",
+        name: "preferred-trust",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Trust details</span>
+            Is there a preferred trust for these academies?',
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--xl"
+          }
+        },
+        items: [
+          {
+            value: "yes",
+            text: "Yes",
+            checked: data['preferred-trust'] === 'yes'
+          },
+          {
+            value: "no",
+            text: "No",
+            checked: data['preferred-trust'] === 'no'
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+
+  </div>
+</div>
+{% endblock %} 

--- a/app/views/alpha-sprint-18/incoming-trust-proposed-trust-name.html
+++ b/app/views/alpha-sprint-18/incoming-trust-proposed-trust-name.html
@@ -1,0 +1,41 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Enter proposed trust name" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form class="form" action="proposed-trust-name-handler" method="post">
+      <!--
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      -->
+      {{ govukInput({
+        label: {
+          html: '<span class="govuk-caption-l">Trust details</span>
+          Enter the new trust name',
+          classes: "govuk-label--xl",
+          isPageHeading: true
+        },
+        id: "proposed-trust-name",
+        name: "proposed-trust-name",
+        value: data["proposed-trust-name"]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/incoming-trust-search-results.html
+++ b/app/views/alpha-sprint-18/incoming-trust-search-results.html
@@ -1,0 +1,63 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Trust search results" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" action="incoming-trust-confirmation" method="post">
+      {{ govukRadios({
+        idPrefix: "selected-trust",
+        name: "selected-trust",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Trust details</span>
+            Select a trust',
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--xl"
+          }
+        },
+        hint: {
+          text: "3 trusts found"
+        },
+        items: [
+          {
+            value: '{"name": "Bright Futures Educational Trust", "ref": "TR00123", "companies": "07695402"}',
+            text: "Bright Futures Educational Trust",
+            hint: {
+              text: "TRN: TR00123\nUKPRN: 07695402"
+            }
+          },
+          {
+            value: '{"name": "United Learning Trust", "ref": "TR00456", "companies": "04439859"}',
+            text: "United Learning Trust",
+            hint: {
+              text: "TRN: TR00456\nUKPRN: 04439859"
+            }
+          },
+          {
+            value: '{"name": "The Harris Federation", "ref": "TR00789", "companies": "06228587"}',
+            text: "The Harris Federation",
+            hint: {
+              text: "TRN: TR00789\nUKPRN: 06228587"
+            }
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </form>
+
+  </div>
+</div>
+{% endblock %} 

--- a/app/views/alpha-sprint-18/incoming-trust-search.html
+++ b/app/views/alpha-sprint-18/incoming-trust-search.html
@@ -1,0 +1,38 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Search for incoming trust" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form class="form" action="incoming-trust-search-results" method="post">
+      {{ govukInput({
+        label: {
+          html: '<span class="govuk-caption-l">Trust details</span>
+          Search for the trust by name or reference number',
+          classes: "govuk-label--xl",
+          isPageHeading: true
+        },
+        hint: {
+          text: "For example, search by trust reference number (TRN) or UK provider reference number (UKPRN)"
+        },
+        id: "incoming-trust-search",
+        name: "incoming-trust-search"
+      }) }}
+
+      {{ govukButton({
+        text: "Search"
+      }) }}
+    </form>
+
+  </div>
+</div>
+{% endblock %} 

--- a/app/views/alpha-sprint-18/incoming-trust-summary.html
+++ b/app/views/alpha-sprint-18/incoming-trust-summary.html
@@ -1,0 +1,120 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Trust details summary" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "application-task-list?ref=" + data.application.reference,
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="incoming-trust">
+      Trust details
+    </h1>
+
+    <p class="govuk-body eat-transfer__task-owner-box">
+      {{ taskOwnerDisplay }} <a class="govuk-link" href="task-owner-update?task=incomingTrust">Change</a>
+    </p>
+
+    {% if not data['new-trust'] or data['new-trust'].length === 0 %}
+    <div class="govuk-inset-text">
+      No trust details have been added.
+    </div>
+    <a href="incoming-trust-new-trust-question" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+      Add trust details
+    </a>
+    {% else %}
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          New trust being formed
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ "Yes" if data['new-trust'] === 'yes' else "No" }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="incoming-trust-new-trust-question">
+            Change<span class="govuk-visually-hidden"> new trust answer</span>
+          </a>
+        </dd>
+      </div>
+
+      {% if data['new-trust'] === 'yes' %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Trust name
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['proposed-trust-name'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="incoming-trust-proposed-trust-name">
+            Change<span class="govuk-visually-hidden"> trust name</span>
+          </a>
+        </dd>
+      </div>
+      {% else %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Preferred trust identified
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ "Yes" if data['preferred-trust'] === 'yes' else "No" }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="incoming-trust-preferred-trust-question">
+            Change<span class="govuk-visually-hidden"> preferred trust answer</span>
+          </a>
+        </dd>
+      </div>
+
+      {% if data['preferred-trust'] === 'yes' and data['selected-trust'] %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Selected trust
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body">{{ data.selectedTrust.name }}</p>
+          <p class="govuk-body">TRN: {{ data.selectedTrust.ref }}</p>
+          <p class="govuk-body govuk-!-margin-bottom-0">UKPRN: {{ data.selectedTrust.companies }}</p>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="incoming-trust-search">
+            Change<span class="govuk-visually-hidden"> selected trust</span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
+      {% endif %}
+    </dl>
+    {% endif %}
+
+    <form action="application-task-list" method="post">
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="incoming-trust-status" name="incoming-trust-status" type="checkbox" value="Complete" {% if data['incoming-trust-status'] %}checked{% endif %}>
+            <label class="govuk-label govuk-checkboxes__label" for="incoming-trust-status">
+              Mark this section as complete, you can still make changes later
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/landing-page.html
+++ b/app/views/alpha-sprint-18/landing-page.html
@@ -1,0 +1,396 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% block content %}
+
+<style>
+  .gem-c-contents-list__list-item--dashed {
+    display: flex;
+    align-items: baseline;
+    margin-bottom: 8px;
+  }
+
+  .gem-c-contents-list__list-item--dashed .gem-c-contents-list__list-item-dash::before {
+    content: "—";
+    margin-right: 8px;
+  }
+
+  h2 {
+    margin: 0 0 20px 0 !important;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-size: 27px !important;
+    font-weight: 700;
+    font-size: 1.3125rem;
+    line-height: 1.1904761905;
+  }
+</style>
+
+<main role="main" id="content" class="detailed-guide govuk-main-wrapper" lang="en">
+  <span id="Top"></span>
+
+
+
+
+  <div class="govuk-grid-row gem-print-columns-none">
+    <div class="govuk-grid-column-two-thirds">
+
+      <div class="gem-c-heading govuk-!-margin-bottom-8">
+        <span class="govuk-caption-xl gem-c-heading__context">
+          Guidance
+        </span>
+
+
+        <h1 class="gem-c-heading__text govuk-heading-l">
+          Apply to transfer an academy to another trust
+        </h1>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+      <p class="gem-c-lead-paragraph govuk-body-l">
+        Make an application to transfer an academy from one trust to another.
+      </p>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="metadata-logo-wrapper gem-print-columns-none " style="border-top: 1px solid #b1b4b6;">
+      <div class="govuk-grid-column-two-thirds metadata-column">
+        <div data-module="metadata" class="gem-c-metadata" style="margin-bottom: 40px;" data-metadata-module-started="true">
+          <dl class="gem-c-metadata__list">
+            <dt class="gem-c-metadata__term govuk-body-s" style="float: inline-start;">From:</dt>
+            <dd class="gem-c-metadata__definition govuk-body-s" data-module="gem-toggle" data-gem-toggle-module-started="true">
+              <a class="govuk-link" href="/government/organisations/department-for-education">Department for
+                Education</a>
+
+            </dd>
+          </dl>
+        </div>
+      </div>
+      <div class="govuk-grid-column-one-third">
+      </div>
+    </div>
+  </div>
+
+
+
+  <div data-button-location="top" data-button-text-subscribe="Get emails about this page"
+    data-button-text-unsubscribe="Stop getting emails about this page" data-module="ga4-link-tracker"
+    class="gem-c-single-page-notification-button govuk-!-display-none-print govuk-!-margin-bottom-6"
+    data-ga4-link-tracker-module-started="true">
+    <form action="/email/subscriptions/single-page/new" method="POST">
+      <input type="hidden" name="base_path" value="/guidance/apply-to-transfer-an-academy-to-another-trust">
+      <button class="govuk-body-s gem-c-single-page-notification-button__submit" style="padding: 10px; background: none;margin: 0; border: 1px solid #505a5f;" type="submit"
+        data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;subscribe&quot;,&quot;index_link&quot;:1,&quot;index_total&quot;:2,&quot;section&quot;:&quot;Top&quot;,&quot;url&quot;:&quot;/email/subscriptions/single-page/new&quot;}">
+        <svg class="gem-c-single-page-notification-button__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
+          height="18" width="18" viewBox="0 0 459.334 459.334">
+          <path fill="currentColor"
+            d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z">
+          </path>
+        </svg><span class="gem-c-single-page-notication-button__text" style="color: #1d70b8; cursor: pointer;">Get emails about this page</span>
+      </button>
+    </form>
+  </div>
+
+
+  <div class="govuk-grid-row gem-print-columns-none">
+    <div class="govuk-grid-column-two-thirds">
+
+      <section data-ga4-devolved-nations-banner="England" data-module="ga4-link-tracker" data-ga4-track-links-only=""
+        data-ga4-set-indexes=""
+        data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;devolved nations banner&quot;,&quot;section&quot;:&quot;Applies to England&quot;}"
+        aria-label="Nation" class="gem-c-devolved-nations" style="background: #f3f2f1; margin-bottom: 50px; padding: 20px 30px;" data-ga4-link-tracker-module-started="true">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
+          Applies to England
+        </h2>
+      </section>
+
+      <div id="contents" data-module="contents-list-with-body" class="gem-c-contents-list-with-body"
+        data-contents-list-with-body-module-started="true">
+        <div class="gem-c-contents-list-with-body__list-container" style="margin-bottom: 50px;">
+          <nav data-module="ga4-link-tracker" aria-label="Contents" class="gem-c-contents-list govuk-!-margin-bottom-4"
+            data-ga4-link-tracker-module-started="true">
+            <h2 class="gem-c-contents-list__title govuk-body-s">
+              Contents
+            </h2>
+            <ol class="gem-c-contents-list__list" style="margin: 0;padding: 0; list-style-type: none;">
+              <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+                <span class="gem-c-contents-list__list-item-dash" aria-hidden="true"></span>
+                <a class="gem-c-contents-list__link govuk-link gem-c-force-print-link-styles govuk-link--no-underline"
+                  data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:8,&quot;index_link&quot;:1}"
+                  href="#who-should-use-this-guidance">Who should use this guidance</a>
+              </li>
+              <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+                <span class="gem-c-contents-list__list-item-dash" aria-hidden="true"></span>
+                <a class="gem-c-contents-list__link govuk-link gem-c-force-print-link-styles govuk-link--no-underline"
+                  data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:8,&quot;index_link&quot;:2}"
+                  href="#other-support">Other support</a>
+              </li>
+              <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+                <span class="gem-c-contents-list__list-item-dash" aria-hidden="true"></span>
+                <a class="gem-c-contents-list__link govuk-link gem-c-force-print-link-styles govuk-link--no-underline"
+                  data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:8,&quot;index_link&quot;:3}"
+                  href="#before-you-start">Before you start</a>
+              </li>
+              <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+                <span class="gem-c-contents-list__list-item-dash" aria-hidden="true"></span>
+                <a class="gem-c-contents-list__link govuk-link gem-c-force-print-link-styles govuk-link--no-underline"
+                  data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:8,&quot;index_link&quot;:4}"
+                  href="#apply-to-transfer-an-academy">Apply to transfer an academy</a>
+              </li>
+              <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+                <span class="gem-c-contents-list__list-item-dash" aria-hidden="true"></span>
+                <a class="gem-c-contents-list__link govuk-link gem-c-force-print-link-styles govuk-link--no-underline"
+                  data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:8,&quot;index_link&quot;:5}"
+                  href="#what-happens-next">What happens next</a>
+              </li>
+              <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+                <span class="gem-c-contents-list__list-item-dash" aria-hidden="true"></span>
+                <a class="gem-c-contents-list__link govuk-link gem-c-force-print-link-styles govuk-link--no-underline"
+                  data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:8,&quot;index_link&quot;:6}"
+                  href="#get-a-decision-from-dfe-before-you-make-any-changes">Get a decision from DfE before you make
+                  any changes</a>
+              </li>
+              <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+                <span class="gem-c-contents-list__list-item-dash" aria-hidden="true"></span>
+                <a class="gem-c-contents-list__link govuk-link gem-c-force-print-link-styles govuk-link--no-underline"
+                  data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:8,&quot;index_link&quot;:7}"
+                  href="#get-a-solicitor">Get a solicitor</a>
+              </li>
+              <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+                <span class="gem-c-contents-list__list-item-dash" aria-hidden="true"></span>
+                <a class="gem-c-contents-list__link govuk-link gem-c-force-print-link-styles govuk-link--no-underline"
+                  data-ga4-link="{&quot;event_name&quot;:&quot;select_content&quot;,&quot;section&quot;:&quot;Contents&quot;,&quot;type&quot;:&quot;contents list&quot;,&quot;index_total&quot;:8,&quot;index_link&quot;:8}"
+                  href="#inform-parents-and-staff">Inform parents and staff</a>
+              </li>
+            </ol>
+          </nav>
+        </div>
+
+        <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-bottom-6">
+          <button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link"
+            data-print-link-module-started="true">Print this page</button>
+        </div>
+
+        <div data-module="govspeak" class="gem-c-govspeak govuk-govspeak govuk-!-margin-bottom-0"
+          data-govspeak-module-started="true">
+
+          <div class="govspeak">
+            <h2 id="who-should-use-this-guidance" class="govuk-heading-m">Who should use this guidance</h2>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>Single academy trusts (<abbr title="single academy trusts">SATs</abbr>) that want to add other
+                maintained schools or academies by using their existing legal entity, and becoming a new multi-academy
+                trust (<abbr title="multi-academy trust">MAT</abbr>)</li>
+              <li>
+                <abbr title="multi-academy trusts">MATs</abbr> that want to add an academy or academies from <abbr
+                  title="single academy trusts">SATs</abbr>
+              </li>
+              <li>
+                <abbr title="multi-academy trusts">MATs</abbr> that want to add an academy or academies from a different
+                <abbr title="multi-academy trust">MAT</abbr>
+              </li>
+              <li>
+                <abbr title="multi-academy trusts">MATs</abbr> merging or consolidating, where all the academies from
+                one trust are transferring to another trust
+              </li>
+            </ul>
+
+            <h2 id="other-support" class="govuk-heading-m">Other support</h2>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>
+                <abbr title="single academy trusts">SATs</abbr> or <abbr title="multi-academy trusts">MATs</abbr> who
+                want to add a new free school to their trust must complete a <a
+                  href="https://www.gov.uk/government/collections/opening-a-free-school" class="govuk-link">free school
+                  application</a>
+              </li>
+              <li>
+                <abbr title="multi-academy trusts">MATs</abbr> who want to add schools that are applying to become
+                academies should direct schools to the <a
+                  href="https://www.gov.uk/government/publications/academy-conversion-application-forms"
+                  class="govuk-link">Apply to become an academy</a> online service - these schools may need additional
+                information from the trust to complete their application
+              </li>
+              <li>
+                <abbr title="multi-academy trusts">MATs</abbr> who want to merge or consolidate and form a new <abbr
+                  title="multi-academy trust">MAT</abbr> should discuss plans with their named Regions Group contactat
+                Department for Education (DfE)
+              </li>
+              <li>Groups of schools forming a new <abbr title="multi-academy trust">MAT</abbr> should apply to convert
+                using <a href="https://www.gov.uk/government/publications/academy-conversion-application-forms"
+                  class="govuk-link">Apply to become an academy</a> online service - the lead school should complete
+                this form using the <a href="https://www.gov.uk/guidance/convert-to-an-academy-information-for-schools"
+                  class="govuk-link">Convert to an academy: guide for schools</a>.</li>
+            </ul>
+
+            <h2 id="before-you-start" class="govuk-heading-m">Before you start</h2>
+
+            <p class="govuk-body">If you have already provided some information to DfE, speak to your DfE delivery officer or named contact
+              before completing this form. If you do not have a lead contact for your trust, find the Regional
+              Director's Office for your area using the About Us section of the <a
+                href="https://www.gov.uk/government/organisations/regional-department-for-education-dfe-directors/about"
+                class="govuk-link">Regional Department for Education Directors</a>.</p>
+
+            <h2 id="apply-to-transfer-an-academy" class="govuk-heading-m">Apply to transfer an academy</h2>
+
+            <p class="govuk-body">Fill in the online form to request to transfer an academy from one trust to another.</p>
+
+            <p class="govuk-body">You need names of the:</p>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>academies involved, including unique reference numbers</li>
+              <li>trustees</li>
+              <li>members</li>
+              <li>the date you want to transfer</li>
+            </ul>
+
+            <a href="dashboard.html" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-3 govuk-!-margin-bottom-9" data-module="govuk-button">
+              Start
+              <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+                <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+              </svg>
+            </a>
+
+            <h2 id="what-happens-next" class="govuk-heading-m">What happens next</h2>
+
+            <p>All plans to grow an academy trust will need to be agreed by the Regions Group (RG) for your area.</p>
+
+            <p><strong>Additional sentence about what happens next, for example when trusts will find out DfE's
+                decision.</strong></p>
+
+            <p><a
+                href="https://www.gov.uk/government/publications/multi-academy-trusts-establishing-and-developing-your-trust"
+                class="govuk-link">Multi-academy trusts: establishing and developing your trust</a> has more information
+              about how <abbr title="multi-academy trusts">MATs</abbr> can grow their trust.</p>
+
+            <p><a href="https://www.gov.uk/government/publications/commissioning-high-quality-trusts"
+                class="govuk-link">Commissioning high-quality trusts</a> has information about how the DfE makes academy
+              trust commissioning decisions and the five pillars of strong trusts.</p>
+
+            <p><a href="https://www.gov.uk/government/publications/academy-transfers-information-for-academy-trusts"
+                class="govuk-link">Academy transfers: information for academy trusts</a> has information for existing
+              <abbr title="single academy trusts">SATs</abbr> or <abbr title="multi-academy trusts">MATs</abbr> that
+              want to add academies from another <abbr title="single academy trust">SAT</abbr> or <abbr
+                title="multi-academy trust">MAT</abbr>.</p>
+
+            <h2 id="get-a-decision-from-dfe-before-you-make-any-changes" class="govuk-heading-m">Get a decision from DfE before you make any
+              changes</h2>
+
+            <p>You must have approval for your application from the DfE Regions Group before you make any changes to the
+              articles of association or any other trust documents.</p>
+
+            <p>Academy transfers are decided based on the details given in their existing funding agreement. If current
+              provision is different from the funding agreement, you will need written approval from DfE through the <a
+                href="https://www.gov.uk/government/publications/making-significant-changes-to-an-existing-academy"
+                class="govuk-link">making a significant change process</a>. For example differences in capacity, age
+              range or resource provision. Discuss next steps with your DfE named contact if this applies to your
+              application. &nbsp;</p>
+
+            <h2 id="get-a-solicitor" class="govuk-heading-m">Get a solicitor</h2>
+
+            <p>Consider getting a solicitor to advise you on the changes needed to:</p>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>your trust documents</li>
+              <li>any other legal, charity or statutory requirements that may apply</li>
+            </ul>
+
+            <p>For example <a rel="external" href="https://www.legislation.gov.uk/uksi/2006/246/contents"
+                class="govuk-link">The Transfer of Undertakings (Protection of Employment) Regulations 2006</a> (TUPE)
+              or the <a rel="external" href="https://www.legislation.gov.uk/ukpga/2010/15/contents"
+                class="govuk-link">Equality Act 2010</a>.</p>
+
+            <h2 id="inform-parents-and-staff" class="govuk-heading-m">Inform parents and staff</h2>
+
+            <p>As public bodies, academy trusts should also consider whether they need to consult on their proposed
+              changes. In all cases, it is good practice for trusts to inform parents, staff and other interested
+              parties about their plans, and give them the opportunity to respond.</p>
+
+          </div>
+
+        </div>
+
+
+
+        <div class="published-dates-button-group">
+          <h2 class="govuk-visually-hidden">
+            Sign up for emails or print this page
+          </h2>
+
+          <div data-button-location="bottom" data-button-text-subscribe="Get emails about this page"
+            data-button-text-unsubscribe="Stop getting emails about this page" data-module="ga4-link-tracker"
+            class="gem-c-single-page-notification-button govuk-!-display-none-print govuk-!-margin-bottom-3"
+            data-ga4-link-tracker-module-started="true">
+            <form action="/email/subscriptions/single-page/new" method="POST">
+              <input type="hidden" name="base_path" value="/guidance/apply-to-transfer-an-academy-to-another-trust">
+              <button class="govuk-body-s gem-c-single-page-notification-button__submit" type="submit"
+                data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;subscribe&quot;,&quot;index_link&quot;:2,&quot;index_total&quot;:2,&quot;section&quot;:&quot;Footer&quot;,&quot;url&quot;:&quot;/email/subscriptions/single-page/new&quot;}">
+                <svg class="gem-c-single-page-notification-button__icon" aria-hidden="true"
+                  xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334">
+                  <path fill="currentColor"
+                    d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z">
+                  </path>
+                </svg><span class="gem-c-single-page-notication-button__text">Get emails about this page</span>
+              </button>
+            </form>
+          </div>
+          <div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-bottom-8">
+            <button class="govuk-link govuk-body-s gem-c-print-link__button" data-module="print-link"
+              data-print-link-module-started="true">Print this page</button>
+          </div>
+        </div>
+
+
+
+        <div data-sticky-element=""
+          class="gem-c-contents-list-with-body__link-wrapper gem-c-contents-list-with-body__sticky-element--hidden gem-c-contents-list-with-body__sticky-element--stuck-to-window gem-c-contents-list-with-body__sticky-element--enabled">
+          <div class="gem-c-contents-list-with-body__link-container">
+
+            <a class="govuk-link gem-c-back-to-top-link govuk-!-display-none-print" href="#contents">
+              <svg class="gem-c-back-to-top-link__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17"
+                viewBox="0 0 13 17" aria-hidden="true" focusable="false">
+                <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+              </svg>
+              Contents
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+
+      <div class="gem-c-contextual-sidebar govuk-!-display-none-print"></div>
+    </div>
+
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <div class="gem-c-contextual-footer govuk-!-display-none-print">
+        <div data-module="ga4-link-tracker" class="gem-c-related-navigation govuk-!-display-none-print"
+          data-ga4-link-tracker-module-started="true">
+
+
+
+          <nav class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-topics-8d52971e"
+            data-module="gem-toggle" data-gem-toggle-module-started="true">
+
+          </nav>
+
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+
+
+</main>
+
+
+{% endblock %}

--- a/app/views/alpha-sprint-18/layouts/govuk.html
+++ b/app/views/alpha-sprint-18/layouts/govuk.html
@@ -1,0 +1,79 @@
+{% extends "layouts/main.html" %}
+
+{% block header %}
+<header class="govuk-header" role="banner" data-module="govuk-header">
+  <div class="govuk-header__container govuk-width-container" style="max-width: 960px;">
+    <div class="govuk-header__logo">
+      <a href="/" class="govuk-header__link govuk-header__link--homepage">
+        <span class="govuk-header__logotype">
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            class="govuk-header__logotype-crown"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 132 97"
+            height="30"
+            width="36"
+          >
+            <path
+              fill="currentColor" fill-rule="evenodd"
+              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
+            ></path>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
+          </span>
+        </span>
+      </a>
+    </div>
+  </div>
+</header>
+{% endblock %}
+
+{% block main %}
+<div class="govuk-width-container" style="max-width: 960px;">
+  {% block beforeContent %}{% endblock %}
+  <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+    {% block content %}{% endblock %}
+  </main>
+</div>
+{% endblock %}
+
+{% block footer %}
+<footer class="govuk-footer" role="contentinfo">
+  <div class="govuk-width-container" style="max-width: 960px;">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          class="govuk-footer__licence-logo"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 483.2 195.7"
+          height="17"
+          width="41"
+        >
+          <path
+            fill="currentColor"
+            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+          />
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a
+            class="govuk-footer__link"
+            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+            rel="license"
+          >Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a
+          class="govuk-footer__link govuk-footer__copyright-logo"
+          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+        >© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>
+{% endblock %} 

--- a/app/views/alpha-sprint-18/member-add.html
+++ b/app/views/alpha-sprint-18/member-add.html
@@ -1,0 +1,45 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Full name of the member" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to Members",
+    href: "members-summary",
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+      Full name of the member
+    </h1>
+
+    <p class="govuk-body">
+      Enter the full name of the member who will be part of the trust after the transfer.
+    </p>
+
+    <form action="member-confirmation" method="post">
+      
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="member-full-name">
+          Full name
+        </label>
+        <input class="govuk-input" id="member-full-name" name="member-full-name" type="text" value="{{ data['member-full-name'] }}">
+      </div>
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+      
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/member-confirmation.html
+++ b/app/views/alpha-sprint-18/member-confirmation.html
@@ -1,0 +1,52 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Is this the right member?" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to Add a member by name",
+    href: "member-add",
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <form action="member-current-responsibilities" method="post">
+      
+      {{ govukRadios({
+        name: "member-confirmed",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Members</span>
+            Is ' + data['member-full-name'] + ' an existing member or a new one?',
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+        },
+        items: [
+          {
+            value: "Yes",
+            text: "Yes",
+            checked: data["member-confirmed"] === "Yes"
+          },
+          {
+            value: "No",
+            text: "No",
+            checked: data["member-confirmed"] === "No"
+          }
+        ]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+      
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/member-current-responsibilities.html
+++ b/app/views/alpha-sprint-18/member-current-responsibilities.html
@@ -1,0 +1,52 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What roles and responsibilities have they had in the past 5 years?" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to Is this the right member?",
+    href: "member-confirmation",
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    
+    <form action="member-future-role" method="post">
+      
+      {{ govukCharacterCount({
+        label: {
+          html: '<span class="govuk-caption-l">Members</span>
+          What roles and responsibilities has ' + data['member-full-name'] + ' had in the past 5 years?',
+          classes: "govuk-label--l",
+          isPageHeading: true
+        },
+        hint: {
+          html: '<p class="govuk-body">Include:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>any employment, self-employment, non-exec roles</li>
+            <li>dates</li>
+            <li>names of any schools, academy trusts or other educational institutions</li>
+            <li>explanation of how the roles demonstrate expertise and skills needed for their role as members</li>
+          </ul>'
+        },
+        maxlength: 4000,
+        id: "member-current-responsibilities",
+        name: "member-current-responsibilities",
+        value: data["member-current-responsibilities"]
+      }) }}
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+      
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/member-future-role.html
+++ b/app/views/alpha-sprint-18/member-future-role.html
@@ -1,0 +1,62 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Future role and responsibilities" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to Current responsibilities",
+    href: "member-current-responsibilities",
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    
+    <form action="members-summary" method="post">
+      
+      {{ govukCheckboxes({
+        name: "member-future-role",
+        fieldset: {
+          legend: {
+            html: '<span class="govuk-caption-l">Members</span>
+            Will ' + data['member-full-name'] + ' also have any of these roles?',
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+        },
+        hint: {
+          text: "Select all that apply. The majority of members should not also be trustees."
+        },
+        items: [
+          {
+            value: "Trustee",
+            text: "Trustee",
+            checked: data["member-future-role"] and data["member-future-role"].includes("Trustee")
+          },
+          {
+            value: "Part of a local governing body",
+            text: "Part of a local governing body",
+            checked: data["member-future-role"] and data["member-future-role"].includes("Part of a local governing body")
+          },
+          {
+            value: "None of these",
+            text: "None of these",
+            checked: data["member-future-role"] and data["member-future-role"].includes("None of these")
+          }
+        ]
+      }) }}
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+      
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/member-to-remove-add.html
+++ b/app/views/alpha-sprint-18/member-to-remove-add.html
@@ -1,0 +1,45 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Add a member to remove" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to Members",
+    href: "members-summary",
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+      Add a member to remove
+    </h1>
+
+    <p class="govuk-body">
+      Enter the full name of the current member who will be removed from the trust after the transfer.
+    </p>
+
+    <form action="members-summary" method="post">
+      
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="member-to-remove-full-name">
+          Full name
+        </label>
+        <input class="govuk-input" id="member-to-remove-full-name" name="member-to-remove-full-name" type="text" value="{{ data['member-to-remove-full-name'] }}">
+      </div>
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+      
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/members-summary.html
+++ b/app/views/alpha-sprint-18/members-summary.html
@@ -1,0 +1,175 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Members" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "application-task-list?ref=" + data.application.reference,
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="members">
+      Members
+    </h1>
+
+    <h2 class="govuk-heading-m">Members after the transfer</h2>
+    
+    <div class="govuk-hint">
+      The trust must have at least 3 members and should have 5 or more.
+      Members must not be employees of the trust.
+    </div>
+    
+    {% if not data['members-to-add'] or data['members-to-add'].length === 0 %}
+      <div class="govuk-inset-text">
+        No members have been added.
+      </div>
+    {% else %}
+      {% for member in data['members-to-add'] %}
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h3 class="govuk-summary-card__title">Member {{ loop.index }}</h3>
+            <div class="govuk-summary-card__actions">
+              <a class="govuk-link" href="confirm-delete-member?index={{ loop.index0 }}">
+                Remove<span class="govuk-visually-hidden"> member {{ loop.index }}</span>
+              </a>
+            </div>
+          </div>
+          <div class="govuk-summary-card__content">
+            <dl class="govuk-summary-list">
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Name
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  <p class="govuk-body">{{ member.name }}</p>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                  <a class="govuk-link" href="member-add?edit={{ loop.index0 }}">
+                    Change<span class="govuk-visually-hidden"> member {{ loop.index }} name</span>
+                  </a>
+                </dd>
+              </div>
+              {% if member.isExistingMember is defined %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Is {{ member.name }} an existing member or a new one?
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  <p class="govuk-body">{% if member.isExistingMember %}Yes{% else %}No{% endif %}</p>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                  <a class="govuk-link" href="member-confirmation">
+                    Change<span class="govuk-visually-hidden"> member confirmation for {{ member.name }}</span>
+                  </a>
+                </dd>
+              </div>
+              {% endif %}
+              {% if member.currentResponsibilities %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  What roles and responsibilities has {{ member.name }} had in the past 5 years?
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  <p class="govuk-body">{{ member.currentResponsibilities }}</p>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                  <a class="govuk-link" href="member-current-responsibilities?member={{ loop.index0 }}">
+                    Change<span class="govuk-visually-hidden"> current responsibilities for {{ member.name }}</span>
+                  </a>
+                </dd>
+              </div>
+              {% endif %}
+              {% if member.futureRole %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Will {{ member.name }} also have any of these roles?
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {% if member.futureRole is string %}
+                    <p class="govuk-body">{{ member.futureRole }}</p>
+                  {% else %}
+                    <ul class="govuk-list govuk-list--bullet">
+                      {% for role in member.futureRole %}
+                        {% if role and role !== '_unchecked' %}
+                          <li>{{ role }}</li>
+                        {% endif %}
+                      {% endfor %}
+                    </ul>
+                  {% endif %}
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                  <a class="govuk-link" href="member-future-role?member={{ loop.index0 }}">
+                    Change<span class="govuk-visually-hidden"> future role for {{ member.name }}</span>
+                  </a>
+                </dd>
+              </div>
+              {% endif %}
+            </dl>
+          </div>
+        </div>
+      {% endfor %}
+    {% endif %}
+
+    <a href="member-add" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-9" data-module="govuk-button">
+      Add member
+    </a>
+
+    <h2 class="govuk-heading-m">Current members who will be leaving</h2>
+    
+    {% if not data['members-to-remove'] or data['members-to-remove'].length === 0 %}
+      <div class="govuk-inset-text">
+        No members have been marked for removal.
+      </div>
+    {% else %}
+      <dl class="govuk-summary-list">
+        {% for member in data['members-to-remove'] %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Person to leave {{ loop.index }}
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <p class="govuk-body">{{ member.name }}</p>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="confirm-delete-member-to-remove?index={{ loop.index0 }}">
+                Remove<span class="govuk-visually-hidden"> person to leave {{ loop.index }}</span>
+              </a>
+            </dd>
+          </div>
+        {% endfor %}
+      </dl>
+    {% endif %}
+
+    <a href="member-to-remove-add" role="button" draggable="false" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-9" data-module="govuk-button">
+      Add person
+    </a>
+
+    <form action="application-task-list" method="post">
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="members-status" name="members-status" type="checkbox" value="Complete" {% if data['members-status'] %}checked{% endif %}>
+            <label class="govuk-label govuk-checkboxes__label" for="members-status">
+              Mark this section as complete, you can still make changes later
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/reason-and-benefits-academies-benefit-trust.html
+++ b/app/views/alpha-sprint-18/reason-and-benefits-academies-benefit-trust.html
@@ -1,0 +1,41 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="How will the transferring academies benefit the trust" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="reason-and-benefits-academies-benefit-trust-handler" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Reason and benefits</span>
+            How will the transferring academies benefit the trust?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          maxlength: 4000,
+          id: "reason-and-benefits-academies-benefit-trust",
+          name: "reason-and-benefits-academies-benefit-trust",
+          value: data["reason-and-benefits-academies-benefit-trust"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/reason-and-benefits-academies-maintain-improve.html
+++ b/app/views/alpha-sprint-18/reason-and-benefits-academies-maintain-improve.html
@@ -1,0 +1,41 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="How will the transferring academies help maintain and improve existing academies in the trust" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="reason-and-benefits-academies-maintain-improve-handler" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Reason and benefits</span>
+            How will the transferring academies help maintain and improve existing academies in the trust?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          maxlength: 4000,
+          id: "reason-and-benefits-academies-maintain-improve",
+          name: "reason-and-benefits-academies-maintain-improve",
+          value: data["reason-and-benefits-academies-maintain-improve"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/reason-and-benefits-academies-strategic-needs.html
+++ b/app/views/alpha-sprint-18/reason-and-benefits-academies-strategic-needs.html
@@ -1,0 +1,44 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What are the strategic needs" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="reason-and-benefits-academies-summary" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Reason and benefits</span>
+            What are the strategic needs of the transferring academies and their local areas?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          hint: {
+            text: "Include any diocesan plans"
+          },
+          maxlength: 4000,
+          id: "reason-and-benefits-academies-strategic-needs",
+          name: "reason-and-benefits-academies-strategic-needs",
+          value: data["reason-and-benefits-academies-strategic-needs"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/alpha-sprint-18/reason-and-benefits-academies.html
+++ b/app/views/alpha-sprint-18/reason-and-benefits-academies.html
@@ -1,0 +1,90 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Reason and benefits" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "application-task-list?ref=" + data.application.reference,
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="reason-and-benefits-academies">
+      Reason and benefits
+    </h1>
+
+    <p class="govuk-body eat-transfer__task-owner-box">
+      {{ taskOwnerDisplay }} <a class="govuk-link" href="task-owner-update?task=reason-and-benefits-academies">Change</a>
+    </p>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          What are the strategic needs of the transferring academies and their local areas?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['reason-and-benefits-academies-strategic-needs'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="reason-and-benefits-academies-strategic-needs">
+            Change<span class="govuk-visually-hidden"> strategic needs</span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          How will the transferring academies help maintain and improve existing academies in the trust?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['reason-and-benefits-academies-maintain-improve'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="reason-and-benefits-academies-maintain-improve">
+            Change<span class="govuk-visually-hidden"> how will the transferring academies help maintain and improve existing academies</span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          How will the transferring academies benefit the trust?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['reason-and-benefits-academies-benefit-trust'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="reason-and-benefits-academies-benefit-trust">
+            Change<span class="govuk-visually-hidden"> how will the transferring academies benefit the trust</span>
+          </a>
+        </dd>
+      </div>
+    </dl>
+    
+
+    <form action="application-task-list" method="post">
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="reason-and-benefits-academies-status" name="reason-and-benefits-academies-status" type="checkbox" value="Complete" {% if data['reason-and-benefits-academies-status'] %}checked{% endif %}>
+            <label class="govuk-label govuk-checkboxes__label" for="reason-and-benefits-academies-status">
+              Mark this section as complete, you can still make changes later
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/reason-and-benefits-trust-maintain-improve.html
+++ b/app/views/alpha-sprint-18/reason-and-benefits-trust-maintain-improve.html
@@ -1,0 +1,41 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="How will the transferring academies help maintain and improve existing academies in the trust" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="reason-and-benefits-trust-maintain-improve-handler" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Reason and benefits</span>
+            How will the trust support the developmental needs of the transferring academies?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          maxlength: 4000,
+          id: "reason-and-benefits-trust-maintain-improve",
+          name: "reason-and-benefits-trust-maintain-improve",
+          value: data["reason-and-benefits-trust-maintain-improve"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/reason-and-benefits-trust-strategic-needs.html
+++ b/app/views/alpha-sprint-18/reason-and-benefits-trust-strategic-needs.html
@@ -1,0 +1,41 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What are the strategic needs of the transferring academies and their local areas" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="reason-and-benefits-trust-strategic-needs-handler" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Reason and benefits</span>
+            What are the strategic needs of the trust?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          maxlength: 4000,
+          id: "reason-and-benefits-trust-strategic-needs",
+          name: "reason-and-benefits-trust-strategic-needs",
+          value: data["reason-and-benefits-trust-strategic-needs"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/reason-and-benefits-trust-transfer-type.html
+++ b/app/views/alpha-sprint-18/reason-and-benefits-trust-transfer-type.html
@@ -1,0 +1,62 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What type of transfer it is" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="reason-and-benefits-trust-transfer-type-handler" method="post">
+
+        {{ govukRadios({
+          name: "reason-and-benefits-trust-transfer-type",
+          fieldset: {
+            legend: {
+              html: '<span class="govuk-caption-l">Reason and benefits</span>
+              What type of transfer it is?',
+              classes: "govuk-fieldset__legend--l",
+              isPageHeading: true
+            }
+          },
+          items: [
+            {
+              value: "Academies joining a SAT",
+              text: "Academies joining a SAT",
+              checked: data["reason-and-benefits-trust-transfer-type"] === "Academies joining a SAT"
+            },
+            {
+              value: "SATs joining a MAT",
+              text: "SATs joining a MAT",
+              checked: data["reason-and-benefits-trust-transfer-type"] === "SATs joining a MAT"
+            },
+            {
+              value: "2 MATS merging",
+              text: "2 MATS merging",
+              checked: data["reason-and-benefits-trust-transfer-type"] === "2 MATS merging"
+            },
+            {
+              value: "An academy from a MAT joining another MAT",
+              text: "An academy from a MAT joining another MAT",
+              checked: data["reason-and-benefits-trust-transfer-type"] === "An academy from a MAT joining another MAT"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/reason-and-benefits-trust.html
+++ b/app/views/alpha-sprint-18/reason-and-benefits-trust.html
@@ -1,0 +1,92 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Reason and benefits" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "application-task-list?ref=" + data.application.reference,
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="reason-and-benefits-trust">
+      Reason and benefits
+    </h1>
+
+    <p class="govuk-body eat-transfer__task-owner-box">
+      {{ taskOwnerDisplay }} <a class="govuk-link" href="task-owner-update?task=reason-and-benefits-trust">Change</a>
+    </p>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          What are the strategic needs of the trust?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['reason-and-benefits-trust-strategic-needs'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="reason-and-benefits-trust-strategic-needs">
+            Change<span class="govuk-visually-hidden"> strategic needs</span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          How will the trust support the developmental needs of the transferring academies?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['reason-and-benefits-trust-maintain-improve'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="reason-and-benefits-trust-maintain-improve">
+            Change<span class="govuk-visually-hidden"> how will the trust support the developmental needs</span>
+          </a>
+        </dd>
+      </div>
+      <!-- Temporarily hidden: What type of transfer it is?
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          What type of transfer it is?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['reason-and-benefits-trust-transfer-type'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="reason-and-benefits-trust-transfer-type">
+            Change<span class="govuk-visually-hidden"> what type of transfer it is</span>
+          </a>
+        </dd>
+      </div>
+      -->
+    </dl>
+    
+
+    <form action="application-task-list" method="post">
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="reason-and-benefits-trust-status" name="reason-and-benefits-trust-status" type="checkbox" value="Complete" {% if data['reason-and-benefits-trust-status'] %}checked{% endif %}>
+            <label class="govuk-label govuk-checkboxes__label" for="reason-and-benefits-trust-status">
+              Mark this section as complete, you can still make changes later
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/risks-due-diligence.html
+++ b/app/views/alpha-sprint-18/risks-due-diligence.html
@@ -1,0 +1,44 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What due diligence activities have been carried out" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="risks-summary" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Risks</span>
+            What due diligence activities have been carried out on the transferring academies?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          hint: {
+            text: "Describe the due diligence activities that have been undertaken"
+          },
+          maxlength: 4000,
+          id: "risks-due-diligence",
+          name: "risks-due-diligence",
+          value: data["risks-due-diligence"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/risks-finances-pooled.html
+++ b/app/views/alpha-sprint-18/risks-finances-pooled.html
@@ -1,0 +1,52 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Are any transferring academy's finances currently pooled" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="risks-summary" method="post">
+
+        {{ govukRadios({
+          name: "risks-finances-pooled",
+          fieldset: {
+            legend: {
+              html: '<span class="govuk-caption-l">Risks</span>
+              Are any transferring academy\'s finances currently pooled?',
+              classes: "govuk-fieldset__legend--l",
+              isPageHeading: true
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes",
+              checked: data["risks-finances-pooled"] === "Yes"
+            },
+            {
+              value: "No",
+              text: "No",
+              checked: data["risks-finances-pooled"] === "No"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/risks-financial-deficit.html
+++ b/app/views/alpha-sprint-18/risks-financial-deficit.html
@@ -1,0 +1,52 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Do any transferring academy have an in-year deficit or overall deficit" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="risks-summary" method="post">
+
+        {{ govukRadios({
+          name: "risks-financial-deficit",
+          fieldset: {
+            legend: {
+              html: '<span class="govuk-caption-l">Risks</span>
+              Do any transferring academy have an in-year deficit or overall deficit?',
+              classes: "govuk-fieldset__legend--l",
+              isPageHeading: true
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes",
+              checked: data["risks-financial-deficit"] === "Yes"
+            },
+            {
+              value: "No",
+              text: "No",
+              checked: data["risks-financial-deficit"] === "No"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/risks-financial-forecast.html
+++ b/app/views/alpha-sprint-18/risks-financial-forecast.html
@@ -1,0 +1,44 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Provide a 3 year financial forecast" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="risks-summary" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Risks</span>
+            Provide a 3 year financial forecast for the academy and your plans to bring the academy into surplus',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          hint: {
+            text: "Include your financial forecast and plans to achieve surplus"
+          },
+          maxlength: 4000,
+          id: "risks-financial-forecast",
+          name: "risks-financial-forecast",
+          value: data["risks-financial-forecast"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/risks-other-risks.html
+++ b/app/views/alpha-sprint-18/risks-other-risks.html
@@ -1,0 +1,52 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Are there other risks related to the transferring academies" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="risks-summary" method="post">
+
+        {{ govukRadios({
+          name: "risks-other-risks",
+          fieldset: {
+            legend: {
+              html: '<span class="govuk-caption-l">Risks</span>
+              Are there other risks related to the transferring academies?',
+              classes: "govuk-fieldset__legend--l",
+              isPageHeading: true
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes",
+              checked: data["risks-other-risks"] === "Yes"
+            },
+            {
+              value: "No",
+              text: "No",
+              checked: data["risks-other-risks"] === "No"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/risks-pupil-forecast.html
+++ b/app/views/alpha-sprint-18/risks-pupil-forecast.html
@@ -1,0 +1,44 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Provide a 3 year forecast of pupil numbers" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="risks-summary" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Risks</span>
+            Provide a 3 year forecast of pupil numbers and plans to improve this',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          hint: {
+            text: "Include your forecast and any plans to improve pupil numbers"
+          },
+          maxlength: 4000,
+          id: "risks-pupil-forecast",
+          name: "risks-pupil-forecast",
+          value: data["risks-pupil-forecast"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/risks-pupil-numbers.html
+++ b/app/views/alpha-sprint-18/risks-pupil-numbers.html
@@ -1,0 +1,52 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Are pupil numbers expected to drop below 85%" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="risks-summary" method="post">
+
+        {{ govukRadios({
+          name: "risks-pupil-numbers",
+          fieldset: {
+            legend: {
+              html: '<span class="govuk-caption-l">Risks</span>
+              Are pupil numbers in any transferring academy expected to drop below 85% of the school capacity?',
+              classes: "govuk-fieldset__legend--l",
+              isPageHeading: true
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes",
+              checked: data["risks-pupil-numbers"] === "Yes"
+            },
+            {
+              value: "No",
+              text: "No",
+              checked: data["risks-pupil-numbers"] === "No"
+            }
+          ]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/risks-reserves-transfer.html
+++ b/app/views/alpha-sprint-18/risks-reserves-transfer.html
@@ -1,0 +1,44 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="How much of the reserves and funding will transfer over" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="risks-summary" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Risks</span>
+            How much of the reserves and funding allocated to the academies will transfer over?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          hint: {
+            text: "Provide details about the reserves and funding that will transfer"
+          },
+          maxlength: 4000,
+          id: "risks-reserves-transfer",
+          name: "risks-reserves-transfer",
+          value: data["risks-reserves-transfer"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/risks-risk-management.html
+++ b/app/views/alpha-sprint-18/risks-risk-management.html
@@ -1,0 +1,44 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What are the risks and the plans to manage them" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="risks-summary" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">Risks</span>
+            What are the risks and the plans to manage them?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          hint: {
+            text: "Describe the risks and your plans to manage them"
+          },
+          maxlength: 4000,
+          id: "risks-risk-management",
+          name: "risks-risk-management",
+          value: data["risks-risk-management"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/risks-summary.html
+++ b/app/views/alpha-sprint-18/risks-summary.html
@@ -1,0 +1,176 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Risks" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "application-task-list?ref=" + data.application.reference,
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="risks">
+      Risks
+    </h1>
+
+    <p class="govuk-body eat-transfer__task-owner-box">
+      {{ taskOwnerDisplay }} <a class="govuk-link" href="task-owner-update?task=risks">Change</a>
+    </p>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          What due diligence activities have been carried out on the transferring academies?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['risks-due-diligence'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="risks-due-diligence">
+            Change<span class="govuk-visually-hidden"> due diligence activities</span>
+          </a>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Are pupil numbers in any transferring academy expected to drop below 85% of the school capacity?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['risks-pupil-numbers'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="risks-pupil-numbers">
+            Change<span class="govuk-visually-hidden"> pupil numbers</span>
+          </a>
+        </dd>
+      </div>
+      {% if data['risks-pupil-numbers'] === 'Yes' %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Provide a 3 year forecast of pupil numbers and plans to improve this
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['risks-pupil-forecast'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="risks-pupil-forecast">
+            Change<span class="govuk-visually-hidden"> pupil forecast</span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Do any transferring academy have an in-year deficit or overall deficit?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['risks-financial-deficit'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="risks-financial-deficit">
+            Change<span class="govuk-visually-hidden"> financial deficit</span>
+          </a>
+        </dd>
+      </div>
+      {% if data['risks-financial-deficit'] === 'Yes' %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Provide a 3 year financial forecast for the academy and your plans to bring the academy into surplus
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['risks-financial-forecast'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="risks-financial-forecast">
+            Change<span class="govuk-visually-hidden"> financial forecast</span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Are any transferring academy's finances currently pooled?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['risks-finances-pooled'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="risks-finances-pooled">
+            Change<span class="govuk-visually-hidden"> finances pooled</span>
+          </a>
+        </dd>
+      </div>
+      {% if data['risks-finances-pooled'] === 'Yes' %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          How much of the reserves and funding allocated to the academies will transfer over?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['risks-reserves-transfer'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="risks-reserves-transfer">
+            Change<span class="govuk-visually-hidden"> reserves transfer</span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Are there other risks related to the transferring academies?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['risks-other-risks'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="risks-other-risks">
+            Change<span class="govuk-visually-hidden"> other risks</span>
+          </a>
+        </dd>
+      </div>
+      {% if data['risks-other-risks'] === 'Yes' %}
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          What are the risks and the plans to manage them?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['risks-risk-management'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="risks-risk-management">
+            Change<span class="govuk-visually-hidden"> risk management</span>
+          </a>
+        </dd>
+      </div>
+      {% endif %}
+    </dl>
+    
+
+    <form action="application-task-list" method="post">
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="risks-status" name="risks-status" type="checkbox" value="Complete" {% if data['risks-status'] %}checked{% endif %}>
+            <label class="govuk-label govuk-checkboxes__label" for="risks-status">
+              Mark this section as complete, you can still make changes later
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/school-improvement-model.html
+++ b/app/views/alpha-sprint-18/school-improvement-model.html
@@ -1,0 +1,48 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="What will be the trust's school improvement model and how will it be actioned?" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript:window.history.back()"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+
+    <form action="school-improvement-model-handler" method="post">
+
+        {{ govukCharacterCount({
+          label: {
+            html: '<span class="govuk-caption-l">School improvement</span>
+            What will be the trust\'s school improvement model and how will it be actioned?',
+            classes: "govuk-label--l",
+            isPageHeading: true
+          },
+          hint: {
+            html: '<p class="govuk-body">For example:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>use of school improvement leadership from the academy joining the trust</li>
+              <li>evidence showing how the trust has improved similar academies</li>
+            </ul>'
+          },
+          maxlength: 4000,
+          id: "school-improvement-model",
+          name: "school-improvement-model",
+          value: data["school-improvement-model"]
+        }) }}
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/school-improvement.html
+++ b/app/views/alpha-sprint-18/school-improvement.html
@@ -1,0 +1,64 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="School improvement" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to application task list",
+    href: "application-task-list?ref=" + data.application.reference,
+    classes: "govuk-!-margin-top-6"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6" id="school-improvement">
+      School improvement
+    </h1>
+
+    <p class="govuk-body eat-transfer__task-owner-box">
+      {{ taskOwnerDisplay }} <a class="govuk-link" href="task-owner-update?task=school-improvement">Change</a>
+    </p>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          What will be the trust's school improvement model and how will it be actioned?
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data['school-improvement-model'] }}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="school-improvement-model">
+            Change<span class="govuk-visually-hidden"> school improvement model</span>
+          </a>
+        </dd>
+      </div>
+    </dl>
+    
+
+    <form action="application-task-list" method="post">
+      <input type="hidden" name="from-check-answers" value="{{ 'true' if data['from-check-answers'] else 'false' }}">
+      <div class="govuk-form-group">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="school-improvement-status" name="school-improvement-status" type="checkbox" value="Complete" {% if data['school-improvement-status'] %}checked{% endif %}>
+            <label class="govuk-label govuk-checkboxes__label" for="school-improvement-status">
+              Mark this section as complete, you can still make changes later
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </div>
+    </form>
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/alpha-sprint-18/task-owner-update.html
+++ b/app/views/alpha-sprint-18/task-owner-update.html
@@ -1,0 +1,63 @@
+{% extends "layouts/main.html" %}
+
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set pageName="Assign task to someone" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "application-task-list?ref=" + data.application.reference
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {% if task == 'academies' %}
+      <span class="govuk-caption-l">Details of academies</span>
+    {% elif task == 'incomingTrust' %}
+      <span class="govuk-caption-l">Incoming trust</span>
+    {% elif task == 'reason-and-benefits-academies' %}
+      <span class="govuk-caption-l">Reason and benefits</span>
+    {% elif task == 'reason-and-benefits-trust' %}
+      <span class="govuk-caption-l">Reason and benefits</span>
+    {% elif task == 'risks' %}
+      <span class="govuk-caption-l">Risks</span>
+    {% elif task == 'school-improvement' %}
+      <span class="govuk-caption-l">School improvement</span>
+    {% endif %}
+
+    <h1 class="govuk-heading-xl">
+      Assign task to someone
+    </h1>
+
+    <form action="task-owner-update-handler?task={{ task }}" method="post">
+      {{ govukCheckboxes({
+        name: "task-owner",
+        fieldset: {
+          legend: {
+            text: "Select all that apply",
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        items: checkboxItems,
+        values: currentTaskOwnerEmails
+      }) }}
+
+      {{ govukButton({
+        text: "Save and continue"
+      }) }}
+    </form>
+
+    <p class="govuk-body govuk-!-margin-bottom-6">
+      Can't see the person you want to assign the task to? <a href="contributors-home" class="govuk-link">Invite them to the application</a>.
+    </p>
+    
+  </div>
+</div>
+
+{% endblock %} 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -27,15 +27,7 @@
     <div class="prototype-index-card">
       <p>This is the prototype for alpha sprint 18.</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>Show the contributors home page upfront for new applications. </li>
-        <li>Updated the task list to include the new tasks.</li>
-        <li>Added the reason and benefits task (academies)</li>
-        <li>Added the Risks task</li>
-        <li>Added the reason and benefits task (trust)</li>
-        <li>Added the High-quality and inclusive education task</li>
-        <li>Added the School improvement task</li>
-        <li>Added the Members task</li>
-        <li>Iterated the declaration task</li>
+        <li>Sprint 18 prototype added</li>
       </ul>
     </div>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -20,6 +20,47 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters" style="border-top: 1px solid #b1b4b6; padding-top: 30px;">
 
+    <h2 class="govuk-heading-l" id="alpha-sprint-18">
+      Alpha sprint 18
+    </h2>
+
+    <div class="prototype-index-card">
+      <p>This is the prototype for alpha sprint 18.</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Show the contributors home page upfront for new applications. </li>
+        <li>Updated the task list to include the new tasks.</li>
+        <li>Added the reason and benefits task (academies)</li>
+        <li>Added the Risks task</li>
+        <li>Added the reason and benefits task (trust)</li>
+        <li>Added the High-quality and inclusive education task</li>
+        <li>Added the School improvement task</li>
+        <li>Added the Members task</li>
+        <li>Iterated the declaration task</li>
+      </ul>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-3">To-be journey (new application)</h4>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>The lead applicant is Arden Laney</li>
+          <li>Log in as Arden Laney (lead applicant)</li>
+          <li><a class="govuk-link" href="alpha-sprint-18/landing-page?userType=lead" class="govuk-link">Go to landing page</a></li>
+        </ul>  
+        <p></p>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <h4 class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-3">To-be journey (resume applications)</h4>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>The lead applicant is Arden Laney</li>
+          <li>Log in as John Smith (a contributor)</li>
+          <li><a class="govuk-link" href="alpha-sprint-18/landing-page?userType=contributor" class="govuk-link">Go to landing page</a></li>
+        </ul>  
+      </div>
+    </div> 
+    
+    <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
     <h2 class="govuk-heading-l" id="alpha-sprint-16">
       Alpha sprint 16
     </h2>


### PR DESCRIPTION
**1.Created Sprint 18 Structure**
I replicated the entire Sprint 16 structure for Sprint 18 by:
* Copied all view templates: app/views/alpha-sprint-16/* → app/views/alpha-sprint-18/
* Copied routes file: app/routes/alpha-sprint-16.js → app/routes/alpha-sprint-18.js
* Copied data file: app/data/data-alpha-sprint-16.js → app/data/data-alpha-sprint-18.js

**2. Updated Version References**
I updated the Sprint 18 files to use the correct version:
* Routes file: Changed version = "alpha-sprint-16" to version = "alpha-sprint-18"
* Data import: Changed require('../data/data-alpha-sprint-16') to require('../data/data-alpha-sprint-18')


**3. Added Sprint 18 to Index Page**
I added Sprint 18 to the main index page (app/views/index.html) with:
* Navigation links for both lead applicant and contributor journeys
* Feature list matching Sprint 16
* Proper section formatting

Sprint 18 is now fully functional and accessible via:
* New application: /alpha-sprint-18/landing-page?userType=lead
* Resume application: /alpha-sprint-18/landing-page?userType=contributor
* Index page: Links to both journeys

